### PR TITLE
Fixed home button URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx-scylladb-theme"
-version = "0.1.11"
+version = "0.1.12"
 description = "A Sphinx Theme for ScyllaDB projects documentation"
 authors = ["David García <dgarcia360@outlook.com>"]
 exclude = ["docs", "deploy.sh"]

--- a/sphinx_scylladb_theme/404.html
+++ b/sphinx_scylladb_theme/404.html
@@ -24,7 +24,7 @@
             <div class="ttl_404">
               <h1 class="">404</h1>
               <p>The Scylla monster ate your page!<br/><br/>
-                <a href="/" class="button round">Scylla Home</a>
+                <a href="{{ html_baseurl }}" class="button round">Scylla Home</a>
               </p>  
             </div>
             <img class="vertigo" src="{{ html_baseurl }}/_static/img/vertigo.jpg" alt="" >


### PR DESCRIPTION
The "Scylla Home" button on the 404 page was redirecting to ``scylladb.github.io`` and not to the library's docs.