### PR TITLE
Fixed multiversion redirections

### DIFF
--- a/sphinx_scylladb_theme/extensions/redirects.py
+++ b/sphinx_scylladb_theme/extensions/redirects.py
@@ -1,10 +1,15 @@
 import os
 import yaml
+from urllib.parse import urlparse
 
-# Generate a redirection HTML file
+# Generates a redirection HTML file
 def write_html_redirect(redirect_to):
     html = "<html><head><meta http-equiv=\"refresh\" content=\"0; url=" + redirect_to + "\"></head></html>"
     return html
+
+# Returns if a path is an external url
+def is_url(path):
+    return bool(urlparse(path).netloc)
 
 def create_redirects(app, docname):
     redirects_file = app.config.redirects_file
@@ -14,13 +19,16 @@ def create_redirects(app, docname):
         redirects_file = 'docs/' + redirects_file
     if not os.path.exists(redirects_file):
         return
+
     with open(redirects_file, 'r') as yaml_file:
         full_load = yaml.full_load(yaml_file)
         if full_load:
             for from_path, redirect_to in full_load.items():
                 target_path = app.outdir + '/' + from_path
-                if os.getenv("SPHINX_MULTIVERSION_NAME") is not None:
-                    redirect_to = '/' + os.environ['SPHINX_MULTIVERSION_NAME'] + redirect_to
+                
+                if os.getenv("SPHINX_MULTIVERSION_NAME") and not is_url(redirect_to):
+                    redirect_to = app.config.html_baseurl + '/' + os.environ['SPHINX_MULTIVERSION_NAME'] + redirect_to
+                
                 if app.builder.name == 'dirhtml':
                     if not os.path.exists(target_path):
                         os.makedirs(target_path)
@@ -35,7 +43,7 @@ def setup(app):
     app.connect('build-finished', create_redirects)
 
     return {
-        'version': '0.1',
+        'version': '0.2',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }


### PR DESCRIPTION
The redirections extension is not behaving as expected when hosting docs with multiversion in GitHub Pages.

For example, after clicking on "API documentation" in the Sidebar of the next doc https://scylladb.github.io/java-driver/latest/index.html, the page redirects to ``https://scylladb.github.io/latest/api/classes.html`` instead of ``https://scylladb.github.io/java-driver/latest/api/classes.html``.

This PR prepends the html_base_url to the redirected link if the docs are generated with the multiversion command.

