### PR TITLE
Configurable description per project

### DIFF
--- a/sphinx_scylladb_theme/404.html
+++ b/sphinx_scylladb_theme/404.html
@@ -13,7 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>ScyllaDB</title>
-    <meta name="description" content="Scylla is an Apache Cassandra-compatible NoSQL data store that can handle 1 million transactions per second on a single server." />
+    <meta name="description" content="{{ theme_site_description }}"/>
     <link rel="icon" href="//www.scylladb.com/img/favicon.ico" type="image/x-icon"/>
     <link rel="stylesheet" href="{{ html_baseurl }}/_static/css/doc/main.css" type="text/css" />
   </head>

--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -38,7 +38,7 @@
     {{ title }} | Scylla Docs
     {%- endblock %}
     </title>
-    <meta name="description" content="Scylla is an Apache Cassandra-compatible NoSQL data store that can handle 1 million transactions per second on a single server." />
+    <meta name="description" content="{{ theme_site_description }}"/>
 
     <link rel="icon" href="{{ pathto('_static/img/favicon.ico', 1) }}" type="image/x-icon"/>
     <link rel="canonical" href="https://docs.scylladb.com/">

--- a/sphinx_scylladb_theme/theme.conf
+++ b/sphinx_scylladb_theme/theme.conf
@@ -4,5 +4,6 @@ stylesheet = css/doc/main.css
 pygments_style = default
 [options]
 header_links = []
+site_description = Scylla is an Apache Cassandra-compatible NoSQL data store that can handle 1 million transactions per second on a single server.
 github_issues_repository = ''
 show_sidebar_index =


### PR DESCRIPTION
Each project will have its own meta-description. If no custom description is provided, ``Scylla is an Apache Cassandra-compatible NoSQL data store that can handle 1 million transactions per second on a single server`` is used.

To add a custom description to a documentation project, add the option ``site_description`` to the ``html_options`` setting in ``conf.py`` like in:

```
html_theme_options = {
    ...
    'site_description': 'New description',
}
```