### PR TITLE
Update theme dependency automatically

### DIFF
--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-# Clone repo
-git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" --branch gh-pages --single-branch gh-pages
-cp -r docs/_build/dirhtml/* gh-pages
-# Redirect index to latest version
+# Copy contents
+mkdir gh-pages
+cp -r ./docs/_build/dirhtml/* gh-pages
 ./docs/_utils/redirect.sh > gh-pages/index.html
-# Deploy
+
+# Create gh-pages branch
 cd gh-pages
 touch .nojekyll
+git init
 git config --local user.email "action@scylladb.com"
 git config --local user.name "GitHub Action"
+git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git checkout -b gh-pages
+
+# Deploy
 git add .
 git commit -m "Publish docs" || true
 git push origin gh-pages --force

--- a/docs/_utils/pyproject_template.toml
+++ b/docs/_utils/pyproject_template.toml
@@ -6,17 +6,17 @@ authors = ["ScyllaDB Documentation Contributors"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pyyaml = "^5.3"
+pyyaml = "5.3"
 pygments = "2.2.0"
 recommonmark = "0.5.0"
-sphinx-scylladb-theme = "^0.1.10"
+sphinx-scylladb-theme = "~0.1.10"
 sphinx-sitemap = "2.1.0"
-sphinx-autobuild = "^0.7.1"
+sphinx-autobuild = "0.7.1"
 Sphinx = "2.4.4"
-sphinx-multiversion-scylla = "^0.2.4"
+sphinx-multiversion-scylla = "0.2.4"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
+pytest = "5.2"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/_utils/setup.sh
+++ b/docs/_utils/setup.sh
@@ -8,3 +8,5 @@ fi
 which python3 || { echo "Failed to find python3. Try installing Python for your operative system: https://www.python.org/downloads/" && exit 1; }
 which poetry || curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/1.1.3/get-poetry.py | python3 - && source ${HOME}/.poetry/env
 poetry install
+poetry update
+


### PR DESCRIPTION
Installs the latest documentation theme version on every documentation build when there are no breaking changes. 
This will speed up the development of the theme, since it would allow us to release updates without having to submit a PR per repository. https://github.com/scylladb/sphinx-scylladb-theme/issues/75

Also, the ``gh-branch`` existing contents are deleted before publishing the new docs. By doing so, we can make sure there are no conflicts with documentation that was generated previously. https://github.com/scylladb/scylla-monitoring/issues/1087