### PR TITLE
Fixed LATEST_VERSION should be available for all the steps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,8 @@ jobs:
   release:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      LATEST_VERSION: master
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -29,4 +31,3 @@ jobs:
       run : ./docs/_utils/deploy.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        LATEST_VERSION: master


### PR DESCRIPTION
The variable ``LATEST_VERSION`` was set in the last step "deploy".
This PR makes the variable globally available since the step "Build docs" needs to read it too.

Related issue: https://github.com/scylladb/sphinx-scylladb-theme/issues/74