### PR TITLE
Added multiversion preview

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,3 +72,6 @@ multiversion: setup
 	$(POETRY) run sphinx-multiversion source _build/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+multiversionpreview: multiversion
+	$(POETRY) run python3 -m http.server 5500 --directory $(BUILDDIR)/dirhtml


### PR DESCRIPTION
Related issue #86

The command ``make multiversionpreview`` launches a webserver in ``http://0.0.0.0:5500``.

## Limitations

- The command does not rebuild docs when they change like in the ``make preview`` command.
- The command is not aware of which is the latest version since this is defined for GitHub Actions. For this reason,  ``http://0.0.0.0:5500`` shows the list of available folders and it does not redirect the user to the ``LATEST_VERSION`` folder. Making the LATEST_VERSION environment variable available locally looks possible but might introduce breaking changes that should be addressed in every documentation repo.

##  Test this PR

1. Run ``make multiversionpreview``.
2. Open http://0.0.0.0:5500 in a new browser tab.
3. Click on the version you want to preview.

## Rolling-out the changes
Every repo with a ``Makefile`` should include this new command. I'll submit PRs to every affected repository if the solution looks ok.