### PR TITLE
Show multiversion label always

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
     - master
-    tags:       
-    - '**'
+    paths:
+    - 'docs/**'
 jobs:
   release:
     name: Build

--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -142,7 +142,7 @@
         </div>
 
         <div class="large-3 columns">
-            {% if versions and (versions.tags or versions.branches|count>1) %}
+            {% if versions %}
                 {% include 'versioning.html' %}
             {% endif %}
         </div>

--- a/sphinx_scylladb_theme/static/css/doc/ext/versions.css
+++ b/sphinx_scylladb_theme/static/css/doc/ext/versions.css
@@ -34,3 +34,16 @@
     padding: 4px 10px;
     display: block;
 }
+
+.versions-dropdown.single-version .button {
+    cursor: initial;
+    outline: none;
+}
+
+.versions-dropdown.single-version .fa {
+    display: none;
+}
+
+.versions-dropdown.single-version:hover .content {
+    display: none;
+}

--- a/sphinx_scylladb_theme/versioning.html
+++ b/sphinx_scylladb_theme/versioning.html
@@ -1,19 +1,15 @@
-<div class="versions-dropdown">
-    <button class="button"><span class="version">
-
+<div class="versions-dropdown {{ 'single-version' if (not versions.tags and versions.branches|count==1) or (versions.tags|count==1 and not versions.branches) }}">
+    <button class="button">
 	{{current_version.name | replace('-scylla', '') }}
 
 	 <i class="fa fa-caret-down" aria-hidden="true"></i>
     </button>
     <ul class="content">
-  	{%- for item in versions.branches %}
-  	<li><a href="{{ item.url }}">
-		{{ item.name }}
-	</a></li>
-  	{%- endfor %}
-
+        {%- for item in versions.branches %}
+            <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+        {%- endfor %}
         {%- for item in versions.tags|reverse %}
-        <li><a href="{{ item.url }}">{{item.name | replace('-scylla', '')}}</a></li>
+            <li><a href="{{ item.url }}">{{item.name | replace('-scylla', '')}}</a></li>
         {%- endfor %}
     </ul>
 </div>


### PR DESCRIPTION
Closes #99

If there is just one version and multiversion is enabled, the label is shown but the dropdown does not unfold.

## How to test this PR

1. Run ``make multiversionpreview``. Check if the dropdown is working as before.

![image](https://user-images.githubusercontent.com/9107969/103696685-af51e280-4f96-11eb-87fc-7aedac45bec9.png)

2. Edit ``conf.py`` to build just one version. For example:

```
# Whitelist pattern for tags (set to None to ignore all tags)
TAGS = ['stable']
smv_tag_whitelist = multiversion_regex_builder(TAGS)
# Whitelist pattern for branches (set to None to ignore all branches)
BRANCHES = []
````
3. Run ``make multiversionpreview``. Check if the label for the single version is displayed and the dropdown does not unfold.

Note: If you cannot see docs generated for the stable branch, try to run ``git fetch --tags`` to download the latest tags from remote.

![image](https://user-images.githubusercontent.com/9107969/103693953-099c7480-4f92-11eb-8142-8f0e207eb533.png)

## Rolling out the changes

These changes should not break compatibility and will be available the next time we release a new theme version on PyPi.
