### PR TITLE
Safely escape titles

### DIFF
--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -35,7 +35,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>
     {%- block title %}
-    {{ title }} | Scylla Docs
+    {{ title|striptags|e }} | Scylla Docs
     {%- endblock %}
     </title>
     <meta name="description" content="{{ theme_site_description }}"/>
@@ -201,7 +201,7 @@
             <a class="link" href="https://docs.scylladb.com">Docs</a>
             <a class="link" href="https://www.scylladb.com/company/contact-us/">Contact Us</a>
             <a class="link" href="https://www.scylladb.com/company/">About Us</a>
-            <a class="link button" href="https://github.com/{{ theme_github_issues_repository}}/issues/new?title=Issue in page {{ title }}&&body=I%20would%20like%20to%20report%20an%20issue%20in%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix" target="_blank">
+            <a class="link button" href="https://github.com/{{ theme_github_issues_repository}}/issues/new?title=Issue in page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20in%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix" target="_blank">
                 Report an issue on this page</a>
         </div>
         <div class="footer-actions">


### PR DESCRIPTION
Fixes #102 

## How to test this PR

You could create a new .rst page containing a title with text inlined, like in:

```
``text inlined`` - text not inlined
======================

Sample body
````

Then, you would see that the "Report an issue on this page" button is displayed as expected:

![image](https://user-images.githubusercontent.com/9107969/103920044-b567d080-5108-11eb-8d52-5971e551b497.png)

## Rolling out the changes

This PR does not introduce breaking changes. It will be applied on all projects as soon as we release a new version of the theme on PyPi.