### PR TITLE
Set the hide banner setting to true to hide the Scylla summit Banner

### DIFF
--- a/sphinx_scylladb_theme/theme.conf
+++ b/sphinx_scylladb_theme/theme.conf
@@ -6,5 +6,5 @@ pygments_style = default
 header_links = []
 site_description = Scylla is an Apache Cassandra-compatible NoSQL data store that can handle 1 million transactions per second on a single server.
 github_issues_repository = ''
-hide_banner =
+hide_banner = true
 show_sidebar_index =


### PR DESCRIPTION
Set the hide_banner parameter in theme.conf to true to hide the Scylla Summit Banner.
This will allow us to show other banners in the future just by changing the art work.
