### PR TITLE
Added shared rst_prolog

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,10 +85,7 @@ def setup(sphinx):
 
 # Adds version variables for monitoring and manager versions when used in inline text
 rst_prolog = """
-.. |mon_version| replace:: 3.1
-.. |man_version| replace:: 2.0
-.. |rst| replace:: RestructuredText
-.. |mon_root| replace::  :doc:`Scylla Monitoring Stack </operating-scylla/monitoring/index>`
+.. |rst| replace:: reStructuredText
 """ 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/source/contribute/markup-guide.rst
+++ b/docs/source/contribute/markup-guide.rst
@@ -215,13 +215,14 @@ The following markup is used within a line of text.
 Substitutions
 =============
 
-Substitutions are variables. They are declared in any document and defined in the ``conf.py`` file.
+Substitutions are variables. They are declared in any document and defined in the ``conf.py`` file, ``rst_prolog`` setting.
 Do not use substitutions in headings. The reason is the text that replaces the variable may be longer than the line that is over or below the text and this will produce an error.
 Refrain from making up substitutions without discussing it with the doc team first.
 
 Currently, we using the following substitutions:
 
-* ``|rst|`` for |rst|
+* ``|v|`` for |v|
+* ``|x|`` for |x|
 
 Tables
 ------

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -13,6 +13,7 @@ Examples
    links
    lists
    panel-box
+   substitutions
    tables
    tabs
    text
@@ -31,6 +32,7 @@ Examples
   * :doc:`Links <links>`
   * :doc:`Lists <lists>`
   * :doc:`Panel Box <panel-box>`
+  * :doc:`Substitutions <substitutions>`
   * :doc:`Tables <tables>`
   * :doc:`Tabs <tabs>`
   * :doc:`Text <text>`

--- a/docs/source/examples/substitutions.rst
+++ b/docs/source/examples/substitutions.rst
@@ -1,0 +1,20 @@
+=============
+Substitutions
+=============
+
+By default, the theme includes the following substitutions.
+
+Using:
+
+.. code-block:: rst
+
+    Checkmark: |v|
+
+    Cross: |x|
+
+Results in:
+
+Checkmark: |v|
+
+Cross: |x|
+

--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -7,11 +7,30 @@ from sphinx_scylladb_theme._version import version
 def update_context(app, pagename, templatename, context, doctree):
     context["scylladb_theme_version"] = version
 
-def update_config(app, config):
+def override_smv_latest_version(config):
     default = 'master'
     if hasattr(config, 'smv_latest_version') and config.smv_latest_version:
         default = config.smv_latest_version
     config.smv_latest_version = getenv('LATEST_VERSION', default=default)
+    return config.smv_latest_version
+
+def override_rst_prolog(config):
+    substitutions = """
+    .. |v| raw:: html
+        
+        <i class="inline-icon fa fa-check" aria-hidden="true"></i>
+
+    .. |x| raw:: html
+        
+        <i class="inline-icon fa fa-times" aria-hidden="true"></i>
+    """
+    rst_prolog = config.rst_prolog or ''
+    config.rst_prolog = substitutions + rst_prolog
+    return config.rst_prolog
+
+def update_config(app, config):
+    override_smv_latest_version(config)
+    override_rst_prolog(config)
 
 def setup(app):
     """Setup theme"""

--- a/sphinx_scylladb_theme/static/css/doc/doc.css
+++ b/sphinx_scylladb_theme/static/css/doc/doc.css
@@ -107,6 +107,10 @@
     color: #F6374E;
 }
 
+.inline-icon.fa-check {
+  color: #42C4E6;
+}
+
 .meta-bar-section {
     display:none;
 }

--- a/tests/test_sphinx_scylladb_theme.py
+++ b/tests/test_sphinx_scylladb_theme.py
@@ -1,5 +1,23 @@
-from sphinx_scylladb_theme import __version__
+import os
+from sphinx_scylladb_theme import version, override_smv_latest_version, override_rst_prolog
 
+class ConfigStub:
 
-def test_version():
-    assert __version__ == '0.1.0'
+    def __init__(self):
+        self.smv_latest_version = ''
+        self.rst_prolog = ''
+
+def test_override_smv_latest_version_default():
+    config = ConfigStub()
+    assert override_smv_latest_version(config) == 'master'
+
+def test_override_smv_latest_version_env():
+    config = ConfigStub()
+    os.environ["LATEST_VERSION"] = "abc"
+    assert override_smv_latest_version(config) == 'abc'
+
+def test_override_rst_prolog():
+    config = ConfigStub()
+    config.rst_prolog = '|a| raw:: html'
+    assert '|v| raw:: html' in override_rst_prolog(config)
+    assert '|a| raw:: html' in override_rst_prolog(config)


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/167

Adds the substitutions ``|x|`` and ``|v|`` to all themes using font-awesome icons.

## How to test this PR

Run ``make preview``.  In [Markup Guide > Substitutions](http://127.0.0.1:5500/contribute/markup-guide/#substitutions)   you should see:

![image](https://user-images.githubusercontent.com/9107969/118695695-609a3c00-b805-11eb-89b5-46d0093c87d6.png)

## After releasing a new theme version

This change will raise a warning if the project has already defined the substitutions |x| and |v|. I'll submit a PR in the scylla-docs repo removing the existing substitutions. 