### PR TITLE
Fix font awesome CDN

### DIFF
--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -52,6 +52,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/css/doc/main.css', 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/v4-shims.css"/>
     
     {%- block scripts %}
     {{- script() }}


### PR DESCRIPTION
This PR:

- Makes sure Font Awesome 4.7 is loaded.
- Adds a compact library to support 4.7 and 5.0 active simultaneously.

## Context

Font-Awesome icons are not showing correctly. 

![image](https://user-images.githubusercontent.com/9107969/124443549-ad19e680-dd75-11eb-966c-3f92c16e726e.png)

This is because expertrec.js (search extension) updated the Font-Awesome dependency to 5.0, while the theme still uses 4.7:

![image](https://user-images.githubusercontent.com/9107969/124445098-2a922680-dd77-11eb-95cf-ccaceaafe9f6.png)

## How to test this PR

1. Run ``make preview``
2. Links should render as expected: https://sphinx-theme.scylladb.com/stable/examples/links.html

To roll out the change to all projects, we need to:

- [ ] @dgarcia360 Release a new version of the theme with this change applied.
- [ ] @tzach @lauranovich  Build and publish scylla-docs to GitHub Pages