### PR TITLE
Add Edit on GitHub button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,14 +108,16 @@ html_theme_path = ["../.."]
 # further.  For a list of options available for the theme, see the
 # documentation.
 html_theme_options = {
+    "conf_py_path": "docs/source/",
     "banner_button_text": "Learn more",
     "banner_button_url": "https://sphinx-theme.scylladb.com/stable/CHANGELOG",
     "banner_icon_path": "",
     "banner_title_text": "Sphinx ScyllaDB Theme 1.0 is now released 🥳",
+    "hide_edit_this_page_button": "false",
     "hide_sidebar_index": "true",
     "hide_banner": "false",
     "hide_version_dropdown": ["master"],
-    "github_issues_repository": "scylladb/scylla-doc-issues",
+    "github_issues_repository": "scylladb/sphinx-scylladb-theme",
     "github_repository": "scylladb/sphinx-scylladb-theme",
     "site_description": "Sphinx Theme for ScyllaDB projects.",
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,8 +5,12 @@
   <div class="landing landing--floating">
 
 .. hero-box::
+  :button_icon: fa fa-github
+  :button_url: https://github.com/scylladb/sphinx-scylladb-theme
+  :button_text: Source code
   :title: Welcome to Scylla Sphinx Theme documentation
   :image: /_static/img/mascots/scylla-docs.svg
+
 
   The documentation toolchain for Scylla projects.
 


### PR DESCRIPTION
Now that the theme is open-source, we can enable the "Edit on GitHub" option.

## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make preview
````

3. Open http://127.0.0.1:5500/ with your favorite browser, and navigate to an internal page. The Contribute button should have the new option "Edit on GitHub".