### PR TITLE
Update warning message

### DIFF
--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -169,16 +169,13 @@
         <div class="admonition caution">
           <p class="admonition-title">Caution</p>
           <p>
-            {% if current_version.name == theme_default_branch %} You are
-            reading an unstable version of this documentation. {% else %} You
-            are not reading the most current version of the documentation. {%
-            endif %} If you want up-to-date information, please have a look at
-
+            You are not reading the latest stable version of this documentation.
+            If you want up-to-date information, please have a look at
             <a href="{{ vpathto(latest_version.name) }}">
               {% if latest_version in versions.branches %} {{
               latest_version.name | replace(theme_branch_substring_removed, '')
-              }} {% else %} {{ latest_version.name |
-              replace(theme_tag_substring_removed, '') }} {% endif %} </a
+              }}{% else %} {{ latest_version.name |
+              replace(theme_tag_substring_removed, '') }}{% endif %}</a
             >.
           </p>
         </div>


### PR DESCRIPTION
Closes #252 #202 

Updates the warning message to:

>You are not reading the latest stable version of this documentation. If you want up-to-date information, please have a look at X.X.


## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make multiversionpreview
````

3. Open ``http://127.0.0.1:5500/master`` with your favorite browser. 

4. Enter an internal documentation page, the warning should look like:

 ![image](https://user-images.githubusercontent.com/9107969/144221363-89a1bcf7-4bce-46f0-8893-5327ca720402.png)
