### PR TITLE
Release 1.1.1

### DIFF
--- a/docs/source/examples/code-blocks.rst
+++ b/docs/source/examples/code-blocks.rst
@@ -17,24 +17,13 @@ For example using the rst code block before a |rst| example:
    .. tip:: here's a tip
 
 The code block directive can be changed to a language which is supported by |rst|.
-For example, the following code-block is bash. If you add the following code block directive, to the code sample below:
+For example, the following code-block is cql. If you add the following code block directive, to the code sample below:
 
-``.. code-block:: bash``
+``.. code-block:: cql``
 
-.. code-block:: bash
+.. code-block:: cql
 
-   #!/bin/bash
-
-   # Checks if local url matches the original repository
-   original_repo='scylladb/sphinx-scylladb-theme'
-   origin_repo=$(git config --get remote.origin.url)
-   if [[ $origin_repo != *$original_repo* ]]; then
-       echo "Error: You are tring to publish a new version of the theme"\
-            "from your personal fork."\
-            "Clone the repository '${original_repo}' locally,"\
-            "then run 'deploy.sh' from the original project."
-       exit 1
-   fi
+   create_keyspace_statement: CREATE KEYSPACE [ IF NOT EXISTS ] `keyspace_name` WITH `options`
 
 You see that there is syntax highlighting.
 
@@ -43,18 +32,7 @@ You can create code-blocks in any of the following `languages <https://pygments.
 
 .. code-block:: none
 
-   #!/bin/bash
-
-   # Checks if local url matches the original repository
-   original_repo='scylladb/sphinx-scylladb-theme'
-   origin_repo=$(git config --get remote.origin.url)
-   if [[ $origin_repo != *$original_repo* ]]; then
-       echo "Error: You are tring to publish a new version of the theme"\
-            "from your personal fork."\
-            "Clone the repository '${original_repo}' locally,"\
-            "then run 'deploy.sh' from the original project."
-       exit 1
-   fi
+   create_keyspace_statement: CREATE KEYSPACE [ IF NOT EXISTS ] `keyspace_name` WITH `options`
 
 If you are including a large example (an entire file) as a code-block, refer to :doc:`Literal Include <includes>`.
 

--- a/docs/source/github-pages.rst
+++ b/docs/source/github-pages.rst
@@ -29,6 +29,8 @@ The toolchain provides the following workflows under the directory ``.github/wor
     * - ``docs-pr.yaml``
       - Builds the docs when the default branch receives a new pull request or when the pull request receives new commits. The purpose of this workflow is to make sure pull requests do not break the default branch after being merged.
 
+.. caution:: If you modify these workflows in your repository, you will need to maintain the changes. So instead, we recommend you to open an issue in the `sphinx-scylladb-theme repository <https://github.com/scylladb/sphinx-scylladb-theme>`_ so that all projects can benefit from the improvements you made.
+
 Installation
 ------------
 

--- a/docs/source/upgrade/CHANGELOG.md
+++ b/docs/source/upgrade/CHANGELOG.md
@@ -5,19 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 26 January 2022
+## [1.1] - 01 February 2022
 
 **IMPORTANT**: For more information on how to update, see [Migrating from 1.0 to 1.1](https://sphinx-theme.scylladb.com/stable/upgrade/1-0-to-1-1).
 
 ### Added
 
 - [#323](https://github.com/scylladb/sphinx-scylladb-theme/pull/323): The theme includes a new directive to collapse long content and redundant information.
-- [#263](https://github.com/scylladb/sphinx-scylladb-theme/pull/263): We use dependabot to receive automatic notifications when there are new dependency updates.
 - [#300](https://github.com/scylladb/sphinx-scylladb-theme/pull/300) : Support for Sphinx 4.x.
+- [#263](https://github.com/scylladb/sphinx-scylladb-theme/pull/263): We use dependabot to receive automatic notifications when there are new dependency updates.
+- [#229](https://github.com/scylladb/sphinx-scylladb-theme/issues/229): New file-wide metadata options.
+
+## Updated
+
+- [#263](https://github.com/scylladb/sphinx-scylladb-theme/pull/263): Update JavaScript and Python dependencies to the latest version.
+- [#307](https://github.com/scylladb/sphinx-scylladb-theme/issues/307): Before, poetry was installed as a dependency. From this release, you must install Poetry as a prerequisite.
 
 ### Fixed
 
-- [#263](https://github.com/scylladb/sphinx-scylladb-theme/pull/263): Update JavaScript and Python dependencies to the latest version.
 - [#301](https://github.com/scylladb/sphinx-scylladb-theme/pull/301): Tables with headings were not styled.
 - [#309](https://github.com/scylladb/sphinx-scylladb-theme/pull/309): Expertrec added a new component for projects in the search box page. We have re-styled the page to match the theme's look and feel.
 
@@ -219,7 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#59](https://github.com/scylladb/sphinx-scylladb-theme/issues/59): All projects now share a 404 page.
 - [#58](https://github.com/scylladb/sphinx-scylladb-theme/issues/58): Support for redirections.
 
-[1.1.0]: https://github.com/scylladb/sphinx-scylladb-theme/compare/1.0.6...1.1.0
+[1.1]: https://github.com/scylladb/sphinx-scylladb-theme/compare/1.0.6...1.1.0
 [1.0.6]: https://github.com/scylladb/sphinx-scylladb-theme/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/scylladb/sphinx-scylladb-theme/compare/1.0.4...1.0.5
 [1.0]: https://github.com/scylladb/sphinx-scylladb-theme/compare/0.1.25...1.0.4

--- a/poetry.lock
+++ b/poetry.lock
@@ -130,7 +130,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 
 [[package]]
 name = "identify"
-version = "2.4.6"
+version = "2.4.7"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -709,8 +709,8 @@ filelock = [
     {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
 identify = [
-    {file = "identify-2.4.6-py2.py3-none-any.whl", hash = "sha256:cf06b1639e0dca0c184b1504d8b73448c99a68e004a80524c7923b95f7b6837c"},
-    {file = "identify-2.4.6.tar.gz", hash = "sha256:233679e3f61a02015d4293dbccf16aa0e4996f868bd114688b8c124f18826706"},
+    {file = "identify-2.4.7-py2.py3-none-any.whl", hash = "sha256:e64210654dfbca6ced33230eb1b137591a0981425e1a60b4c6c36309f787bbd5"},
+    {file = "identify-2.4.7.tar.gz", hash = "sha256:8408f01e0be25492017346d7dffe7e7711b762b23375c775d24d3bc38618fabc"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx-scylladb-theme"
-version = "1.1.0"
+version = "1.1.1"
 description = "A Sphinx Theme for ScyllaDB documentation projects"
 authors = ["David García <hi@davidgarcia.dev>"]
 exclude = [".github", "config", "docs", ".postcss.config.js", ".prettierrc.json", "deploy.sh", "src", "package.json", "package-lock.json"]

--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -14,7 +14,7 @@ from sphinx_scylladb_theme.extensions import (
     redirects,
     topic_box,
 )
-from sphinx_scylladb_theme.lexers import CQLLexer, DitaaLexer
+from sphinx_scylladb_theme.lexers import cql, ditaa
 
 
 def compute_toc_tree(toctree, maxdepth, collapse):
@@ -91,8 +91,8 @@ def setup(app):
     app.connect("config-inited", update_config)
 
     """Setup lexers"""
-    app.add_lexer("cql", CQLLexer())
-    app.add_lexer("ditaa", DitaaLexer())
+    app.add_lexer("cql", cql.CQLLexer)
+    app.add_lexer("ditaa", ditaa.DitaaLexer)
 
     """Setup thid-party extensions"""
     not_found.setup(app)

--- a/sphinx_scylladb_theme/lexers/__init__.py
+++ b/sphinx_scylladb_theme/lexers/__init__.py
@@ -1,2 +1,0 @@
-from .cql import CQLLexer  # noqa: F401
-from .ditaa import DitaaLexer  # noqa: F401


### PR DESCRIPTION
Fixes an error ``TypeError: 'CQLLexer' object is not callable`` I got when installing the new version of the theme in the project scylla-docs.

From [3.x](https://www.sphinx-doc.org/en/master/changes.html#release-2-1-0-released-jun-02-2019), the function ``add_lexer()`` now takes a Lexer class instead of instance.


Additionally, this PR adds some missing updates in the CHANGELOG.