### PR TITLE
Add link checker on CI

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -1,0 +1,34 @@
+name: "Docs / Links"
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # At 00:00 on Sunday
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.3.2
+        with:
+          args: --verbose --no-progress './**/*.md' './**/*.rst'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+http://0.0.0.0:5500
+http://127.0.0.1:5500
+https://scylladb.github.io

--- a/docs/source/deployment/production.rst
+++ b/docs/source/deployment/production.rst
@@ -28,6 +28,8 @@ The toolchain provides the following workflows under the directory ``.github/wor
       - Builds multi versioned docs every time the default branch (e.g. ``master``)  receives an update. If the build completes successfully, the workflow publishes the HTML version to GitHub Pages.
     * - ``docs-pr.yaml``
       - Builds the docs when the default branch receives a new pull request or when the pull request receives new commits. The purpose of this workflow is to make sure pull requests do not break the default branch after being merged.
+    * - ``docs-links.yaml``
+      -  Looks for broken links once a week. If there are broken links, it creates an issue in the same repository with the list of affected links.
 
 .. caution:: If you modify these workflows in your repository, you will need to maintain the changes. So instead, we recommend you to open an issue in the `sphinx-scylladb-theme repository <https://github.com/scylladb/sphinx-scylladb-theme>`_ so that all projects can benefit from the improvements you made.
 
@@ -43,8 +45,9 @@ To install the workflows:
         project-name/
           ├── .github/
           |   ├── workflows/
-          |   |   ├── docs-pages@vX.yaml
-          |   |   ├── docs-pr@vX.yaml
+          |   |   ├── docs-pages.yaml
+          |   |   ├── docs-pr.yaml
+          |   |   ├── docs-links.yaml
 
 #. If the default branch is not ``master`` or the docs are not under the ``docs`` folder, the workflows to match the project configuration. For example:
 

--- a/docs/source/examples/links.rst
+++ b/docs/source/examples/links.rst
@@ -14,8 +14,8 @@ There are a few links you can use with different purposes.
    * - External Link
      - .. code-block:: rst
 
-          `External Link <https://docs.scylladb.com/some-doc>`_
-     - `External Link <https://docs.scylladb.com/some-doc>`_
+          `External Link <https://docs.scylladb.com/>`_
+     - `External Link <https://docs.scylladb.com/>`_
      - Use this markup to create a link to another site or project. When rendered it has an arrow pointing out icon. It opens the content in a new tab.
    * - Internal Cross-reference
      - .. code-block:: rst

--- a/docs/source/upgrade/CHANGELOG.md
+++ b/docs/source/upgrade/CHANGELOG.md
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#201](https://github.com/scylladb/sphinx-scylladb-theme/pull/201): The promo banner now supports icons with the option theme option `banner_icon_path`. For more information, see [Template Options](https://sphinx-theme.scylladb.com/stable/configuration/template.html).
 - [#201](https://github.com/scylladb/sphinx-scylladb-theme/pull/201): The contribute button adds the option "Edit on GitHub". To configure your project to support this option, read [Template Options](https://sphinx-theme.scylladb.com/stable/configuration/template.html).
 - [#201](https://github.com/scylladb/sphinx-scylladb-theme/pull/201): We run hooks on every commit to automatically point out linting issues.
-- [#201](https://github.com/scylladb/sphinx-scylladb-theme/pull/201): The new workflow `docs-pr` runs on pull requests to make sure docs build without warnings before being merged. For more information, see [Deployment](https://sphinx-theme.scylladb.com/stable/deployment/production.html).
+- [#201](https://github.com/scylladb/sphinx-scylladb-theme/pull/201): The new workflow `docs-pr` runs on pull requests to make sure docs build without warnings before being merged. For more information, see [Deployment](https://sphinx-theme.scylladb.com/branch-1.0/github-pages.html).
 
 ### Changed
 


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/234

Adds [lychee](https://github.com/lycheeverse/lychee), a link checker that finds broken URLs in MarkDown and RestructuredText files.

## How it works

Once a week, a GitHub Action runs lychee to find for broken links in *.md and *.rst files.

If there are broken links, the action will create a new issue in the same repository with the links that have to be fixed.

![image](https://user-images.githubusercontent.com/9107969/156797068-41b63942-da93-4629-91ce-ed5d7edd2ddb.png)

It is possible to exclude some links from the analysis by listing them in the file ``.lycheeignore``.