### PR TITLE
Fix canonical url if multiversion is not used

### DIFF
--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -54,12 +54,23 @@
         <link rel="icon" href="{{ pathto('_static/img/favicon-228x228.png', 1) }}" sizes="192x192" />
         <link rel="apple-touch-icon" href="{{ pathto('_static/img/favicon-228x228.png', 1) }}" />
         <meta name="msapplication-TileImage" href="{{ pathto('_static/img/favicon-228x228.png', 1) }}" />
+
+        {% if pagename == "index" %}
+            {% set canonical_page = "" %}
+        {% elif pagename.endswith("/index") %}
+            {% set canonical_page = pagename[:-("/index"|length)] + "/" %}
+        {% else %}
+            {% set ending = "/" if builder == "dirhtml" else ".html" %}
+            {% set canonical_page = pagename + ending %}
+        {% endif %}
+
         {% if versions and latest_version %}
             {% set latest_slug = rename_latest_version or latest_version.name %}
-            <link rel="canonical" href="{{ html_baseurl }}/{{latest_slug}}/{{ pagename }}.html"/>
+            <link rel="canonical" href="{{ html_baseurl }}/{{latest_slug}}/{{ canonical_page }}"/>
         {% else %}
-            <link rel="canonical" href="{{ html_baseurl }}/{{ pagename }}.html"/>
+            <link rel="canonical" href="{{ html_baseurl }}/{{ canonical_page }}"/>
         {% endif %}
+
         <link rel="author" href="mailto:info@scylladb.com" />
 
         {% block css %}


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/405

Removes `/index.html` in projects that do not use the multi version plugin (e.g scylla-docs), which is causing duplicate content errors.

## How to test this PR

1. Clone this PR.

2. Run ``make preview`` to run the docs without the multiversion plugin.

3. Inspect the code. The canonical tag does not have the "index.html" suffix:

![image](https://user-images.githubusercontent.com/9107969/165276941-2cac7802-d21d-4682-b996-239950d28126.png)
