### PR TITLE
Only check for broken links in docs folder

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -21,7 +21,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.4.1
         with:
-          args: --verbose --no-progress './**/*.md' './**/*.rst'
+          args: --verbose --exclude-mail --no-progress './docs/**/*.md' './docs/**/*.rst'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
Enhancement for the link checker detected in https://github.com/scylladb/care-pet/tree/master/.github/workflows

It will be ported to other projects with the next theme release.