### PR TITLE
Add "docs" prefix and "documentation" label to issues created with "Create an issue"

### DIFF
--- a/sphinx_scylladb_theme/contribute.html
+++ b/sphinx_scylladb_theme/contribute.html
@@ -1,7 +1,7 @@
 {% if theme_github_repository %}
     <ul class="contribute">
         <li class="contribute__item">
-            <a href="https://github.com/{{ theme_github_issues_repository}}/issues/new?title=Issue in page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20in%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix"
+            <a href="https://github.com/{{ theme_github_issues_repository}}/issues/new?title=Doc:%20Issue in page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20in%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix&labels=documentation"
                 target="_blank">
                 <i class="icon fab fa-github" aria-hidden="true"></i>Create an issue
             </a>


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/525

## How to test this PR

1. Build the docs with ``make preview`` and open the preview in your browser.
2. Click on "Create an issue" button.
3. The issue title should have the prefix "Docs:".
4. The issue should have the label "documentation".

![image](https://user-images.githubusercontent.com/9107969/179737926-41181cea-e38d-446b-bc1c-2b9073072849.png)
