### PR TITLE
Show one version in dropdown

### DIFF
--- a/sphinx_scylladb_theme/versions.html
+++ b/sphinx_scylladb_theme/versions.html
@@ -1,32 +1,30 @@
-{% set has_one_version = (not versions.tags and versions.branches|count==1) or (not versions.branches and versions.tags|count==1) %}{% if not has_one_version %}
-    <ul class="dropdown menu scylla-dropdown scylla-dropdown--versions" data-dropdown-menu>
-        <li class="scylla-dropdown__item">
-            <a class="scylla-dropdown__title" href="#">
-                {% if current_version in versions.branches %}
-                    {{ current_version.name | replace(theme_branch_substring_removed, '') }}
-                {% else %}
-                    {{ current_version.name | replace(theme_tag_substring_removed, '') }}
+<ul class="dropdown menu scylla-dropdown scylla-dropdown--versions" data-dropdown-menu>
+    <li class="scylla-dropdown__item">
+        <a class="scylla-dropdown__title" href="#">
+            {% if current_version in versions.branches %}
+                {{ current_version.name | replace(theme_branch_substring_removed, '') }}
+            {% else %}
+                {{ current_version.name | replace(theme_tag_substring_removed, '') }}
+            {% endif %}
+            <i class="chevron scylla-icon scylla-icon--chevron-right"></i>
+        </a>
+        <ul class="menu scylla-dropdown__content">
+            {% for item in versions.branches|reverse %}
+                {% if item.name not in theme_hide_version_dropdown %}
+                    <li>
+                        <a href="{{ item.url }}">{{ item.name | replace(theme_branch_substring_removed, '') }}</a>
+                    </li>
                 {% endif %}
-                <i class="chevron scylla-icon scylla-icon--chevron-right"></i>
-            </a>
-            <ul class="menu scylla-dropdown__content">
-                {% for item in versions.branches|reverse %}
-                    {% if item.name not in theme_hide_version_dropdown %}
-                        <li>
-                            <a href="{{ item.url }}">{{ item.name | replace(theme_branch_substring_removed, '') }}</a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-                {% for item in versions.tags|reverse %}
-                    {% if item.name not in theme_hide_version_dropdown %}
-                        <li>
-                            <a href="{{ item.url }}">
-                                {{item.name | replace(theme_tag_substring_removed, '' ) }}
-                            </a>
-                        </li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        </li>
-    </ul>
-{%endif%}
+            {% endfor %}
+            {% for item in versions.tags|reverse %}
+                {% if item.name not in theme_hide_version_dropdown %}
+                    <li>
+                        <a href="{{ item.url }}">
+                            {{item.name | replace(theme_tag_substring_removed, '' ) }}
+                        </a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+    </li>
+</ul>


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/545

## How to test this PR

1. Clone this PR.
2. Edit the `BRANCHES` arrray in https://github.com/scylladb/sphinx-scylladb-theme/blob/master/docs/source/conf.py#L15 as follows to leave one version:

> BRANCHES = ["branch-1.2"]

3. Run `make multiversionpreview` and open http://localhost:5500. You should see the multiversion dropdown with one version.