### PR TITLE
Fix multiversion selector exact string

### DIFF
--- a/sphinx_scylladb_theme/utils.py
+++ b/sphinx_scylladb_theme/utils.py
@@ -18,4 +18,5 @@ def multiversion_regex_builder(versions):
     elif len(versions) == 1:
         return r"^" + versions[0] + r"$"
     else:
+        versions = [f'^{version}$' for version in versions]
         return r"\b(" + "|".join(versions) + r")\b"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,4 +18,4 @@ def test_multiversion_regex_builder_one_version():
 
 def test_multiversion_regex_builder_many_version():
     versions = ["1.0", "2.0"]
-    assert multiversion_regex_builder(versions) == r"\b(1.0|2.0)\b"
+    assert multiversion_regex_builder(versions) == r"\b(^1.0$|^2.0$)\b"


### PR DESCRIPTION
Fix for https://github.com/scylladb/scylla-manager/issues/3261

Updates the `multiversion_regex_builder` utility to only match exact strings.

Before:

![image](https://user-images.githubusercontent.com/9107969/200548504-aba5ba92-b4fb-4c09-bf82-9fd7c4692718.png)

Now:

![image](https://user-images.githubusercontent.com/9107969/200548440-7736d50d-beb5-48b1-b7e9-8264dca621d2.png)

## How to test this PR


1. Create a new branch "1.3-patch".

``git checkout -b 1.3-patch``

2. Check out this pull request.

3. Build the docs with ``make multiversionpreview``.
You should not see "1.3-patch"  in the multiversion dropdown selector, but "1.3" should still appear:

![image](https://user-images.githubusercontent.com/9107969/200594551-7e8d29d3-5c7e-4b62-aa2f-3c5f5fbae7fd.png)
