### PR TITLE
Raise warning if doc has underscores

### DIFF
--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -14,6 +14,7 @@ from sphinx_scylladb_theme.extensions import (
     navigation,
     panel_box,
     topic_box,
+    validations,
 )
 from sphinx_scylladb_theme.lexers import cql, ditaa
 
@@ -110,5 +111,6 @@ def setup(app):
     multiversion.setup(app)
     panel_box.setup(app)
     topic_box.setup(app)
+    validations.setup(app)
 
     return {"version": version, "parallel_read_safe": True}

--- a/sphinx_scylladb_theme/extensions/validations.py
+++ b/sphinx_scylladb_theme/extensions/validations.py
@@ -1,9 +1,10 @@
 from sphinx.util import logging
 
+logger = logging.getLogger(__name__)
+
 
 def raise_warning_if_document_has_underscores(app, docname, source):
     if "_" in docname:
-        logger = logging.getLogger(__name__)
         logger.warning("Document name contains underscores: %s" % docname)
 
 

--- a/sphinx_scylladb_theme/extensions/validations.py
+++ b/sphinx_scylladb_theme/extensions/validations.py
@@ -1,0 +1,16 @@
+from sphinx.util import logging
+
+
+def raise_warning_if_document_has_underscores(app, docname, source):
+    if "_" in docname:
+        logger = logging.getLogger(__name__)
+        logger.warning("Document name contains underscores: %s" % docname)
+
+
+def setup(app):
+    app.connect("source-read", raise_warning_if_document_has_underscores)
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sphinx_scylladb_theme/extensions/validations.py
+++ b/sphinx_scylladb_theme/extensions/validations.py
@@ -4,8 +4,11 @@ logger = logging.getLogger(__name__)
 
 
 def raise_warning_if_document_has_underscores(app, docname, source):
+    result = False
     if "_" in docname:
         logger.warning("Document name contains underscores: %s" % docname)
+        result = True
+    return result
 
 
 def setup(app):

--- a/tests/extensions/test_validations.py
+++ b/tests/extensions/test_validations.py
@@ -1,12 +1,7 @@
-from sphinx.util import logging
-
-logger = logging.getLogger(__name__)
-
 from sphinx_scylladb_theme.extensions.validations import (
     raise_warning_if_document_has_underscores,
 )
 
 
 def test_raise_warning_if_document_has_underscores():
-    raise_warning_if_document_has_underscores(None, "file_name.rst", None)
-    assert logger.warning.called
+    assert raise_warning_if_document_has_underscores(None, "file_name.rst", None)

--- a/tests/extensions/test_validations.py
+++ b/tests/extensions/test_validations.py
@@ -1,0 +1,11 @@
+from pytest import raises
+from sphinx.errors import SphinxWarning
+
+from sphinx_scylladb_theme.extensions.validations import (
+    raise_warning_if_document_has_underscores,
+)
+
+
+def test_raise_warning_if_document_has_underscores():
+    with raises(SphinxWarning):
+        raise_warning_if_document_has_underscores(None, "file_name.rst", None)

--- a/tests/extensions/test_validations.py
+++ b/tests/extensions/test_validations.py
@@ -1,5 +1,6 @@
-from pytest import raises
-from sphinx.errors import SphinxWarning
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
 
 from sphinx_scylladb_theme.extensions.validations import (
     raise_warning_if_document_has_underscores,
@@ -7,5 +8,5 @@ from sphinx_scylladb_theme.extensions.validations import (
 
 
 def test_raise_warning_if_document_has_underscores():
-    with raises(SphinxWarning):
-        raise_warning_if_document_has_underscores(None, "file_name.rst", None)
+    raise_warning_if_document_has_underscores(None, "file_name.rst", None)
+    assert logger.warning.called


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/210

## How to test this PR

1. Clone this PR.
2. Rename a file within the `docs` folder and add an underscore (e.g. `docs/source/configuration/markdown.md `-> `docs/source/configuration/markdown_test.md`).
3. In the `docs` folder, run ``make preview``.
4. You should see the `Warning: Document name contains underscores: configuartion/markdown_test`.


