### PR TITLE
docs: Add option to skip theme warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,6 @@ html_theme_options = {
     "hide_version_dropdown": ["master"],
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,
-    "skip_warnings": 'document_has_underscores'
 }
 
 # Last updated format

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,6 +107,7 @@ html_theme_options = {
     "hide_version_dropdown": ["master"],
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,
+    "skip_warnings": 'document_has_underscores'
 }
 
 # Last updated format
@@ -124,15 +125,9 @@ html_baseurl = "https://sphinx-theme.scylladb.com"
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {"html_baseurl": html_baseurl}
 
-
 # -- Initialize Sphinx ----------------------------------------------
-def builder_inited(app):
-    # Add custom flags
-    for flag in FLAGS:
-        app.tags.add(flag)
 
 def setup(sphinx):
-    sphinx.connect('builder-inited', builder_inited)
     warnings.filterwarnings(
         action="ignore",
         category=UserWarning,

--- a/docs/source/configuration/template.rst
+++ b/docs/source/configuration/template.rst
@@ -21,6 +21,10 @@ General configuration options.
     - string
     - true
     - Set to ``true`` to load ScyllaDB JS specific scripts, including Google Tag Manager, Expertrec, and Zendesk configuration.
+    * - ``skip_warnings``
+    - string
+    - 
+    - List of custom warnings implemented by the theme to exclude, separated by commas. Available values are: `document_has_underscores`.
 
 Example:
 

--- a/docs/source/configuration/template.rst
+++ b/docs/source/configuration/template.rst
@@ -21,10 +21,10 @@ General configuration options.
     - string
     - true
     - Set to ``true`` to load ScyllaDB JS specific scripts, including Google Tag Manager, Expertrec, and Zendesk configuration.
-    * - ``skip_warnings``
+  * - ``skip_warnings``
     - string
     - 
-    - List of custom warnings implemented by the theme to exclude, separated by commas. Available values are: `document_has_underscores`.
+    - List of custom warnings implemented by the theme to exclude, separated by commas. Available values are: ``document_has_underscores``.
 
 Example:
 

--- a/sphinx_scylladb_theme/extensions/validations.py
+++ b/sphinx_scylladb_theme/extensions/validations.py
@@ -5,6 +5,11 @@ logger = logging.getLogger(__name__)
 
 def raise_warning_if_document_has_underscores(app, docname, source):
     result = False
+    
+    theme_options = app.config.html_theme_options
+    if 'skip_warnings' in theme_options and 'document_has_underscores' in theme_options['skip_warnings']:
+        return result
+    
     if "_" in docname:
         logger.warning("Document name contains underscores: %s" % docname)
         result = True

--- a/sphinx_scylladb_theme/theme.conf
+++ b/sphinx_scylladb_theme/theme.conf
@@ -23,3 +23,4 @@ scylladb_scripts = true
 tag_substring_removed = -scylla
 versions_unstable =
 versions_deprecated=
+skip_warnings=

--- a/tests/extensions/test_validations.py
+++ b/tests/extensions/test_validations.py
@@ -1,7 +1,23 @@
+from unittest.mock import MagicMock
+
 from sphinx_scylladb_theme.extensions.validations import (
     raise_warning_if_document_has_underscores,
 )
 
 
 def test_raise_warning_if_document_has_underscores():
-    assert raise_warning_if_document_has_underscores(None, "file_name.rst", None)
+    app_mock = MagicMock()
+    html_theme_options = {}
+    app_mock.config.html_theme_options = html_theme_options
+
+    assert raise_warning_if_document_has_underscores(app_mock, "file_name.rst", None)
+
+
+def test_skip_raise_warning_if_document_has_underscores():
+    app_mock = MagicMock()
+    html_theme_options = {'skip_warnings': 'document_has_underscores'}
+    app_mock.config.html_theme_options = html_theme_options
+
+    assert raise_warning_if_document_has_underscores(app_mock, "file_name.rst", None) == False
+
+


### PR DESCRIPTION
Option required to update Java and CPP drivers to 1.4.x.

Note that it is not possible to rename some files on these repos since the docs are being synched from an upstream repo.

## How to test

The new option is tested in https://github.com/scylladb/sphinx-scylladb-theme/actions/runs/4577000903/jobs/8081874608?pr=741

