### PR TITLE
Fix sitemap.xml

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ notfound_urls_prefix = ""
 
 # -- Options for sitemap extension ---------------------------------------
 
-sitemap_url_scheme = "stable/{link}"
+sitemap_url_scheme = "/stable/{link}"
 
 # -- Options for multiversion extension ----------------------------------
 


### PR DESCRIPTION
## Motivation

The links in the current `sitemap.xml` file are broken:

![image](https://user-images.githubusercontent.com/9107969/234360749-3a9c710e-2749-41ba-8a90-0ec6ad80e897.png)

Let's use this pull request and repo to test if prepending the backslash generates the correct sitemap URLs.

With the next theme breaking update, we'll backport this change to other projects. See #774 