### PR TITLE
Add local-scripts support

### DIFF
--- a/docs/source/configuration/template.rst
+++ b/docs/source/configuration/template.rst
@@ -17,6 +17,10 @@ General configuration options.
     - Type
     - Default Value
     - Description
+  * - ``local_scripts``
+    - string
+    - true
+    - When set to ``true``, this option enables the loading of the ``local-scripts.html`` file from the template. This file is customizable per project, providing a convenient way to insert project-specific tags and scripts.
   * - ``scylladb_scripts``
     - string
     - true

--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -73,8 +73,11 @@
         {% endblock %}
         {% block scripts %}
             {{ script() }}
+            {% if theme_local_scripts|lower == 'true' %}
+                {% include 'local-scripts.html' %}
+            {% endif %}
             {% if theme_scylladb_scripts|lower == 'true' %}
-                {% include 'custom-scripts.html' %}
+                {% include 'scylladb-scripts.html' %}
             {% endif %}
         {% endblock %}
         <!-- Font Awesome -->

--- a/sphinx_scylladb_theme/local-scripts.html
+++ b/sphinx_scylladb_theme/local-scripts.html
@@ -1,0 +1,2 @@
+<!-- Zendesk tag -->
+<meta name='zd-site-verification' content='gq6ltsh3nfex3cnwfy4aj9' />

--- a/sphinx_scylladb_theme/scylladb-scripts.html
+++ b/sphinx_scylladb_theme/scylladb-scripts.html
@@ -1,6 +1,3 @@
-<!-- Zendesk tag -->
-<meta name='zd-site-verification' content='gq6ltsh3nfex3cnwfy4aj9' />
-
 <!-- Google Tag Manager global -->
 <script>
     (function (w, d, s, l, i) {

--- a/sphinx_scylladb_theme/theme.conf
+++ b/sphinx_scylladb_theme/theme.conf
@@ -20,6 +20,7 @@ hide_version_dropdown =
 hide_versions_dropdown =
 navigation_depth= -1
 site_description = ScyllaDB is an Apache Cassandra-compatible NoSQL data store that can handle 1 million transactions per second on a single server.
+local_scripts = true
 scylladb_scripts = true
 tag_substring_removed = -scylla
 versions_unstable =


### PR DESCRIPTION
## Motivation

This change separates ScyllaDB's global scripts from local scripts, enabling customization of tags and scripts for individual projects at the repo level.

## How it works

Maintainers can override the `local-scripts.html` for a specific project by placing it in the `docs/source/_templates` or `docs/_templates` directory based on the project's setup.

## How to test

Build the docs and inspect the code. You should see the tag loaded in the local-scripts file.

<img width="1439" alt="image" src="https://github.com/scylladb/sphinx-scylladb-theme/assets/9107969/eb1ddb7d-4bcc-44da-ba6d-3d7be4cae2d8">

## Next steps

- Release a new version of the theme (non breaking).
- Add the tags in the following repositories:

   * https://manager.docs.scylladb.com/stable/
   ``<meta name='zd-site-verification' content='jiigc536se3g139312rad' />``

   * https://cloud.docs.scylladb.com/stable/
    ``<meta name='zd-site-verification' content='28bav4hae2utjitn8w2b8s' />``

   * https://enterprise.docs.scylladb.com/stable/
    ``<meta name='zd-site-verification' content='vxmu9cuap9im5l3c3b891' />``
