### PR TITLE
fix importlib dependency (2nd attempt)

### DIFF
--- a/docs/source/upgrade/CHANGELOG.md
+++ b/docs/source/upgrade/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.6.4 - 18 Dec 2023
+## 1.6.5 - 18 Dec 2023
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx-scylladb-theme"
-version = "1.6.4"
+version = "1.6.5"
 description = "A Sphinx Theme for ScyllaDB documentation projects"
 authors = ["David García <hi@davidgarcia.dev>"]
 exclude = [".github", "config", "docs", "extensions", ".postcss.config.js", ".prettierrc.json", "deploy.sh", "src", "package.json", "package-lock.json"]
@@ -15,6 +15,7 @@ sphinx-tabs = "^3.4.1"
 pyyaml = "^6.0.1"
 Sphinx-Substitution-Extensions = "^2022.2.16"
 sphinx-notfound-page = "^1.0.0"
+importlib-metadata = "^6.8.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.2"
@@ -25,7 +26,6 @@ setuptools = "^69.0.2"
 sphinx-multiversion-scylla = "^0.3.1"
 sphinx-sitemap = "^2.5.1"
 redirects_cli ="^0.1.3"
-importlib-metadata = "^6.8.0"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Fixes https://github.com/scylladb/sphinx-scylladb-theme/issues/966

Adds import lib-metadata as a required dependency.

## How to test

Docs should build without errors and [rust build](https://github.com/scylladb/sphinx-scylladb-theme/issues/966) must pass.