### PR TITLE
Add myst_heading_anchors option

### DIFF
--- a/extensions/sphinx-scylladb-markdown/setup.py
+++ b/extensions/sphinx-scylladb-markdown/setup.py
@@ -15,7 +15,7 @@ setup(
     author="David Garcia",
     author_email="hi@davidgarcia.dev",
     url="https://github.com/scylladb/sphinx-scylladb-theme",
-    version="0.1.2",
+    version="0.1.3",
     install_requires=[
         "sphinx >= 2.1",
         "recommonmark == 0.7.1",

--- a/extensions/sphinx-scylladb-markdown/sphinx_scylladb_markdown/__init__.py
+++ b/extensions/sphinx-scylladb-markdown/sphinx_scylladb_markdown/__init__.py
@@ -2,7 +2,7 @@
 import os
 from recommonmark.transform import AutoStructify
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 class BaseParser:
     def __init__(self, app):
@@ -30,6 +30,7 @@ class MystParser(BaseParser):
         try:
             self.app.setup_extension('myst_parser')
             self.app.config.myst_enable_extensions = ["colon_fence"]
+            self.app.config.myst_heading_anchors = 6
 
         except ImportError:
             raise RuntimeError("myst-parser is not installed")


### PR DESCRIPTION
For compatibility and to prevent warnings when transitioning from the existing scylla-operator extension, this PR sets `app.config.myst_heading_anchors = 6`. 

This configuration aligns with the default values used in the Scylla Operator extension (see https://github.com/scylladb/scylla-operator/blob/master/docs/source/_ext/scylladb_markdown.py#L25)