### PR TITLE
Update docs-pages.yaml

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -43,7 +43,7 @@ jobs:
             .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@3.1.3
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar


### PR DESCRIPTION
Freezes `actions/upload-artifact` version for this project. The latest version in main (4.0.0) is not compatible.

Once merged, this should fix https://github.com/scylladb/sphinx-scylladb-theme/actions/runs/7422441033/job/20197764862
