### PR TITLE
Add option to open topic-box in same tab

### DIFF
--- a/docs/source/examples/panel-box.rst
+++ b/docs/source/examples/panel-box.rst
@@ -18,7 +18,7 @@ Syntax
 Options
 -------
 
-The ``topic-box`` directive supports the following options:
+The ``panel-box`` directive supports the following options:
 
 .. list-table::
   :widths: 20 20 10 20 30

--- a/docs/source/examples/topic-box.rst
+++ b/docs/source/examples/topic-box.rst
@@ -54,6 +54,11 @@ The ``topic-box`` directive supports the following options:
     -
     - getting-started
     - Relative link or external URL for the call to action. Do not use leading and trailing ("/") symbols to define relative links. (e.g. instead of ``/getting-started/``, use ``getting-started``).
+  * - ``link_target``
+    - string
+    -
+    - auto
+    - Defines if the link should be opened in a new tab or not. Available values: `auto`, `_blank`, `_self`. Defaults to `auto`.
   * - ``anchor``
     - string
     -
@@ -132,6 +137,32 @@ Results in:
 .. topic-box::
     :title: Lorem Ipsum
     :link: https://scylladb.com
+    :anchor: Lorem ipsum
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+
+Topic with external link (same tab)
+...................................
+
+Using:
+
+.. code-block:: rst
+
+    .. topic-box::
+        :title: Lorem Ipsum
+        :link: https://scylladb.com
+        :link_target: _self
+        :anchor: Lorem ipsum
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+Results in:
+
+.. topic-box::
+    :title: Lorem Ipsum
+    :link: https://scylladb.com
+    :link_target: _self
     :anchor: Lorem ipsum
 
     Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/sphinx_scylladb_theme/extensions/topic_box.py
+++ b/sphinx_scylladb_theme/extensions/topic_box.py
@@ -40,7 +40,7 @@ class TopicBox(Directive):
                 <div class="cell {class_name} {container_class_name}">
                     <a class="card" href="{link}" {target_attr}>
                 """
-            
+
         html_tag_open = generate_template(
             link_template,
             class_name=class_name,

--- a/sphinx_scylladb_theme/extensions/topic_box.py
+++ b/sphinx_scylladb_theme/extensions/topic_box.py
@@ -12,6 +12,7 @@ class TopicBox(Directive):
     option_spec = {
         "title": directives.unchanged_required,
         "link": directives.path,
+        "link_target": directives.path,
         "anchor": directives.path,
         "icon": directives.path,
         "icon_color": directives.path,
@@ -24,21 +25,22 @@ class TopicBox(Directive):
         container_class_name = self.options.get("class", "").replace(",", " ")
 
         link = self.options.get("link")
+        link_target = self.options.get("link_target", "auto")  
         link_template = """
             <div class="{class_name} {container_class_name}">
                 <div class="card">
             """
-        if is_url(link):
-            link_template = """
-            <div class="cell {class_name} {container_class_name}">
-                <a class="card" href="{link}" target="_blank">
-            """
-        elif link:
-            link_template = """
-            <div class="cell {class_name} {container_class_name}">
-                <a class="card" href="{link}">
-            """
-
+        if link:
+            target_attr = ''
+            if link_target == "_blank":
+                target_attr = 'target="_blank"'
+            elif link_target == 'auto' and is_url(link):
+                target_attr = 'target="_blank"'
+            link_template = f"""
+                <div class="cell {class_name} {container_class_name}">
+                    <a class="card" href="{link}" {target_attr}>
+                """
+            
         html_tag_open = generate_template(
             link_template,
             class_name=class_name,
@@ -84,7 +86,7 @@ class TopicBox(Directive):
                  <i class="fa fa-external-link" aria-hidden="true"></i>
                 </div>
                 """
-                if is_url(link)
+                if target_attr == 'target="_blank"'
                 else """
                 <div class="{class_name}__anchor">{anchor}</div>
                 """,


### PR DESCRIPTION
Adds the option to open topic boxes in the same tabs, even if the link is external.

## How to test

1. Build the docs.
2. Open http://127.0.0.1:5500/examples/topic-box/#topic-with-external-link-same-tab
3. The exterrnal link should open on the same tab since it has the `:link_target: _self` set.