### PR TITLE
Add exclude-doctools option

### DIFF
--- a/docs/source/configuration/page.rst
+++ b/docs/source/configuration/page.rst
@@ -88,3 +88,14 @@ If set, hides the version warning from the page.
 .. code-block:: none
 
    :hide-version-warning:
+
+Exclude doctools
+----------------
+
+Excludes ``doctools.js`` from specific documentation pages.
+
+Required to make the toolchain compatible with Swagger UI.
+
+.. code-block:: none
+
+   :exclude-doctools:

--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -51,6 +51,7 @@ def update_context(app, pagename, templatename, context, doctree):
     context["hide_version_warning"] = "hide-version-warning" in file_meta
     context["hide_sidebar"] = "hide-sidebar" in file_meta
     context["hide_secondary_sidebar"] = "hide-secondary-sidebar" in file_meta
+    context["exclude_doctools"] = "exclude-doctools" in file_meta
     context["landing"] = "landing" in file_meta
 
     if (

--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -6,7 +6,9 @@
         <script type="text/javascript" src="{{ pathto('_static/js/runtime.bundle.js', 1) }}"></script>
         <script type="text/javascript" src="{{ pathto('_static/js/main.bundle.js', 1) }}"></script>
         {% for js in script_files %}
-            {{ js_tag(js) }}
+            {% if not (exclude_doctools and 'doctools.js' in js_tag(js)) %}
+                {{ js_tag(js) }}
+            {% endif %}
         {% endfor %}
     {% endmacro %}
     {% macro css() %}


### PR DESCRIPTION
## Motivation

Adds the option to not load the ``doctools.js`` script injected automatically by Sphinx.

We need this option to make the theme compatible with Swagger UI compatible with the 1.2 spec.

## How to test

1. Add the `:exclude-doctools:` at the top of any RST page.
2. Build the docs.
3. Open the page edited in the browser.
3. Inspect the code and search for "doctools.js". You should not see any results.
4. Go to a different page and search for "doctools.js". You should get one result.