### PR TITLE
fix: workflow python version

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Set up env
         run: make -C docs setupenv

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
 
       - name: Set up env
         run: make -C docs setupenv

--- a/docs/source/upgrade/1-6-to-1-7.rst
+++ b/docs/source/upgrade/1-6-to-1-7.rst
@@ -44,7 +44,7 @@ Here are the main breaking changes between the 1.6 and 1.7 versions.
             - name: Set up Python
                 uses: actions/setup-python@v5
                 with:
-                python-version: 3.10
+                python-version: '3.10'
             - name: Set up env
         (...)
 

--- a/docs/source/upgrade/CHANGELOG.md
+++ b/docs/source/upgrade/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.7.1 - 5 Apr 2024
+## 1.7.1 - 12 Apr 2024
 
 ### Added
 
 - [#1023](https://github.com/scylladb/sphinx-scylladb-theme/pull/1023): Added functionality to trigger documentation publications when updates are made to previous versions.
-- [#1059](https://github.com/scylladb/sphinx-scylladb-theme/pull/1059): Introduced an option to open topic boxes in the same tab.
 - [#1058](https://github.com/scylladb/sphinx-scylladb-theme/pull/1058): Added new button styles to the hero box.
+- [#1059](https://github.com/scylladb/sphinx-scylladb-theme/pull/1059): Introduced an option to open topic boxes in the same tab.
+- [#1069](https://github.com/scylladb/sphinx-scylladb-theme/pull/1069): Adds the option to exclude ``doctools.js`` per page to make the theme compatible with Swagger UI.
 
 ### Updated
 


### PR DESCRIPTION
## Motivation

The [Docs / Publish](https://github.com/scylladb/sphinx-scylladb-theme/actions/runs/8658481683/job/23746809898) actions fails.
This is because GitHub is parsing 3.10 as a number as 3.1 rather than a string "3.10".

## How to test

We we'll check it works as expected after merging the PR.

