### PR TITLE
add github label option

### DIFF
--- a/docs/source/configuration/template.rst
+++ b/docs/source/configuration/template.rst
@@ -187,6 +187,10 @@ Configuration options for the Edit on this page button.
     - string
     -
     - Repository organization name and project slug where docs are hosted, separated by a slash (/).
+  * - ``github_label``
+    - string
+    - documentation
+    - Name of the label to be used when creating an issue on GitHub.
   * - ``hide_edit_this_page_button``
     - string
     - true

--- a/sphinx_scylladb_theme/contribute.html
+++ b/sphinx_scylladb_theme/contribute.html
@@ -1,7 +1,7 @@
 {% if theme_github_repository %}
     <ul class="contribute">
         <li class="contribute__item">
-            <a href="https://github.com/{{ theme_github_issues_repository}}/issues/new?title=docs:%20Issue on page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20on%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix&labels=documentation"
+            <a href="https://github.com/{{ theme_github_issues_repository}}/issues/new?title=docs:%20Issue on page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20on%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix&labels={{theme_github_label}}"
                target="_blank">
                 <i class="icon fab fa-github" aria-hidden="true"></i>Create an issue
             </a>

--- a/sphinx_scylladb_theme/feedback.html
+++ b/sphinx_scylladb_theme/feedback.html
@@ -27,7 +27,7 @@
             const themeGithubRepository = {% if theme_github_repository %}true{% else %}false{% endif %};
             let message = 'Great! Thanks for your feedback.';
             if (themeGithubRepository && !liked) {
-                message = "Thanks for your feedback! Please don't hesitate to <a href='https://github.com/{{ theme_github_issues_repository}}/issues/new?title=docs:%20Issue on page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20on%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix&labels=documentation'>create an issue</a> if you have any suggestions on how we can improve.";
+                message = "Thanks for your feedback! Please don't hesitate to <a href='https://github.com/{{ theme_github_issues_repository}}/issues/new?title=docs:%20Issue on page {{ title|striptags|e }}&&body=I%20would%20like%20to%20report%20an%20issue%20on%20page%20{{html_baseurl}}/{% if versions and current_version %}{{ current_version.name }}/{% endif %}{{ pagename }}%0A%0A%23%23%23%20Problem%0A%0A%23%23%23%20%20Suggest%20a%20fix&labels={{theme_github_label}}'>create an issue</a> if you have any suggestions on how we can improve.";
             }
             feedbackMessage.innerHTML = message;
         }

--- a/sphinx_scylladb_theme/theme.conf
+++ b/sphinx_scylladb_theme/theme.conf
@@ -13,6 +13,7 @@ conf_py_path= docs/source/
 default_branch=master
 github_issues_repository = scylladb/scylla-doc-issues
 github_repository=
+github_label=documentation
 hide_banner = true
 hide_feedback_buttons = true
 hide_edit_this_page_button = true


### PR DESCRIPTION
## Motivation

Adds the option to define a GitHub label per project.

## How to test

1. Clone the PR and build the docs.
2. Open an issue from the docs. The "documentation" label should be assigned to the issue.
3. Add the following option `html_theme_options` in `docs/source/conf.py`:

    ```
    html_theme_options = {
    (...)
    "github_label": "bug",
    }
    ```
     
4. Rebuild the docs.
   
5. Open an issue form the docs. The `bug` label should be assigned to the issue.