### PR TITLE
doc: document creating links to configuration parameters

### DIFF
--- a/docs/source/examples/links.rst
+++ b/docs/source/examples/links.rst
@@ -29,6 +29,22 @@ There are a few links you can use with different purposes.
           .. _here:
      - .. _here:
      - This is an internal cross reference bookmark. It requires an internal cross-reference anchor (above). It does not render, but serves as a point to link to.
+   * - Internal Cross-reference to Parameters
+     - .. code-block:: rst
+
+          :ref:`Link to a config param <confprop_parameter_name>`
+     - Renders the parameter name as a hyperlink.
+     - This is an internal cross-reference to a parameter on the `Configuration Parameters <https://opensource.docs.scylladb.com/stable/reference/configuration-parameters.html>`_ page.
+       It does NOT require a bookmark, as parameter names on that are page implicit bookmarks. Content opens in the same tab.
+       This option only applies to the ``scylladb/sylladb`` and ``scylladb/scylla-enterprise`` projects. 
+   * - Internal Cross-reference to Parameter Gropus
+     - .. code-block:: rst
+
+          :ref:`Link to a config param <confgroup_parameter_name>`
+     - Renders the name of the parameter group as a hyperlink.
+     - This is an internal cross-reference to a parameter group on the `Configuration Parameters <https://opensource.docs.scylladb.com/stable/reference/configuration-parameters.html>`_ page.
+       It does NOT require a bookmark, as group names on that are page implicit bookmarks. Content opens in the same tab.
+       This option only applies to the ``scylladb/sylladb`` and ``scylladb/scylla-enterprise`` projects. 
    * - Internal Doc Reference
      - .. code-block:: rst
 


### PR DESCRIPTION
This PR adds an entry to the "Links" table with a description of how to create links to parameters on the automatically generated Configuration Parameters page.