### PR TITLE
fix: add update command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,9 @@ setupenv:
 .PHONY: setup
 setup:
 	$(POETRY) install
+
+.PHONY: update
+update:
 	$(POETRY) update
 
 # Clean commands

--- a/docs/_utils/pyproject_template.toml
+++ b/docs/_utils/pyproject_template.toml
@@ -7,7 +7,7 @@ authors = ["ScyllaDB Documentation Contributors"]
 [tool.poetry.dependencies]
 python = "^3.10"
 pygments = "^2.18.0"
-sphinx-scylladb-theme = "^1.6.1"
+sphinx-scylladb-theme = "^1.8.1"
 myst-parser = "^3.0.1"
 sphinx-autobuild = "^2024.4.19"
 Sphinx = "^7.3.7"

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -27,16 +27,16 @@ Installs system dependencies required to build the docs such as Poetry.
 
     make setupenv
 
-install
-=======
+setup
+=====
 
 Installs the required Python dependencies to build the documentation.
 
 .. code:: console
 
-    make install
+    make setup
 
-.. note:: The command ``make install`` is called automatically when running build commands.
+.. note:: ``make setup`` is called automatically before running build commands.
 
 update
 ======

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -4,16 +4,7 @@ Commands
 
 Use the command-line interface to run the following commands.
 
-Prerequisites
--------------
-
-To run the following commands, you will need to have installed:
-
-- A Unix-based terminal. For Windows, use `Windows Subsystem for Linux <https://learn.microsoft.com/en-us/windows/wsl/install>`_.
-- `Python 3.10 or 3.12 <https://www.python.org/downloads/>`_.
-- `Poetry 1.8.1 <https://python-poetry.org/docs/master/>`_.
-- `Make <https://www.gnu.org/software/make/>`_.
-- `Git <https://git-scm.com/>`_.
+.. note:: Make sure you meet the necessary prerequisites before running these commands. For details, see :ref:`Prerequisites <prerequisites>`.
 
 Setup commands
 --------------
@@ -21,7 +12,7 @@ Setup commands
 setupenv
 ========
 
-Installs system dependencies required to build the docs such as Poetry.
+Installs system dependencies required to build the docs, such as Poetry.
 
 .. code:: console
 
@@ -116,7 +107,7 @@ For further guidance on using the ``multiversionpreview command``, see :doc:`Mul
 dirhtml
 =======
 
-Generates the documentation in HTML version.
+Generates the documentation in HTML format.
 
 .. note:: The command ``make dirhtml`` is aimed to be used by GitHub Actions CI. While documenting new features, it is not advised to run ``make dirhtml``, but ``make preview`` instead.
 
@@ -161,7 +152,8 @@ Clean commands
 clean
 =====
 
-When making changes to the docs, it is helpful to delete the contents of this directory before running ``make preview``.
+Before making changes to the docs, it's helpful to clear the previous build by deleting the contents of the ``build`` directory.
+This ensures that the changes you make are reflected correctly.
 
 .. code:: console
 
@@ -174,7 +166,7 @@ Test commands
 linkcheck
 =========
 
-Checks for broken links on the documentation site.
+Checks the documentation site for broken links.
 
 .. code:: console
 

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -10,17 +10,55 @@ Prerequisites
 To run the following commands, you will need to have installed:
 
 - A Unix-based terminal. For Windows, use `Windows Subsystem for Linux <https://learn.microsoft.com/en-us/windows/wsl/install>`_.
-- `Python 3.7 <https://www.python.org/downloads/>`_ or later.
-- `Poetry #.12 <https://python-poetry.org/docs/master/>`_ or later.
+- `Python 3.10 or 3.12 <https://www.python.org/downloads/>`_.
+- `Poetry 1.8.1 <https://python-poetry.org/docs/master/>`_.
 - `Make <https://www.gnu.org/software/make/>`_.
 - `Git <https://git-scm.com/>`_.
 
+Setup commands
+--------------
+
+setupenv
+========
+
+Installs system dependencies required to build the docs such as Poetry.
+
+.. code:: console
+
+    make setupenv
+
+install
+=======
+
+Installs the required Python dependencies to build the documentation.
+
+.. code:: console
+
+    make install
+
+.. note:: The command ``make install`` is called automatically when running build commands.
+
+update
+======
+
+Updates Python dependencies to the latest version.
+
+.. code:: console
+
+    make update
+
+As a result, updates the ``poetry.lock`` file.
+
+
+Build commands
+--------------
+
 .. _Make_Preview:
 
-Preview current branch
-----------------------
+preview
+=======
 
-The preview command builds a local instance of the docs site so you can view the rendering in a sandbox environment on your local browser.
+Builds a local instance of the docs site so you can view the rendering in a sandbox environment on your local browser.
 
 To preview the docs:
 
@@ -47,7 +85,7 @@ To decrease verbosity, use the option ``-Q``:
 
         make preview SPHINXOPTS=-Q
 
-To fix the error `pyproject.toml changed significantly since poetry.lock was last generated.`, run the following command:
+To fix the error ``pyproject.toml changed significantly since poetry.lock was last generated.``, run the following command:
 
     .. code:: console
 
@@ -55,10 +93,11 @@ To fix the error `pyproject.toml changed significantly since poetry.lock was las
 
     Then, run the preview command again.
 
-Preview multiversion
---------------------
 
-The multiversionpreview command generates a local instance of the docs site with all :doc:`specified versions <../configuration/multiversion>` available for navigation.
+multiversionpreview
+===================
+
+Generates a local instance of the docs site with all :doc:`specified versions <../configuration/multiversion>` available for navigation.
 You can view the rendering in a sandbox environment on your local browser.
 
 To preview multiple versions:
@@ -72,10 +111,26 @@ To preview multiple versions:
 
 #. Open http://0.0.0.0:5500/ with your preferred browser.
 
-For further guidance on using the `multiversionpreview command`, see :doc:`Multiversion configuration <../configuration/multiversion>`.
+For further guidance on using the ``multiversionpreview command``, see :doc:`Multiversion configuration <../configuration/multiversion>`.
 
-Build HTML for multiple versions
---------------------------------
+dirhtml
+=======
+
+Generates the documentation in HTML version.
+
+.. note:: The command ``make dirhtml`` is aimed to be used by GitHub Actions CI. While documenting new features, it is not advised to run ``make dirhtml``, but ``make preview`` instead.
+
+.. code:: console
+
+    cd docs
+    make multiversion
+
+Docs are generated under the ``docs/_build/dirhtml`` directory.
+
+multiversion
+============
+
+Generates multiple versions of the docs with all :doc:`specified versions <../configuration/multiversion>` available for navigation.
 
 .. note:: The command ``make multiversion`` is aimed to be used by GitHub Actions CI. While documenting new features, it is not advised to run ``make multiversion``, but ``make preview`` instead.
 
@@ -84,22 +139,42 @@ Build HTML for multiple versions
     cd docs
     make multiversion
 
-The previous command generates HTML docs under the ``docs/_build/dirhtml`` directory.
+Docs are generated under the ``docs/_build/dirhtml`` directory.
 
-Clean all builds
-----------------
+redirects
+=========
 
-The ``make preview`` operation creates content in the ``_build`` directory. When making changes to the docs, it is helpful to delete the contents of this directory before running ``make preview``.
+Generates HTML redirects from the ``_utils/redirects.yaml`` file.
+
+.. note:: The command ``make multiversion`` is aimed to be used by GitHub Actions CI.
+
+.. code:: console
+
+    cd docs
+    make multiversion
+
+Redirects are generated under the ``docs/_build/dirhtml`` directory.
+
+Clean commands
+--------------
+
+clean
+=====
+
+When making changes to the docs, it is helpful to delete the contents of this directory before running ``make preview``.
 
 .. code:: console
 
     cd docs
     make clean
 
-Check for broken links
-----------------------
+Test commands
+-------------
 
-Check for broken links on the documentation site.
+linkcheck
+=========
+
+Checks for broken links on the documentation site.
 
 .. code:: console
 

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -4,6 +4,8 @@ Quickstart
 
 This guide will show you how to create your first documentation page, list it in the table of contents, and preview the site locally.
 
+.. _prerequisites:
+
 Prerequisites
 -------------
 

--- a/docs/source/upgrade/1-7-to-1-8.rst
+++ b/docs/source/upgrade/1-7-to-1-8.rst
@@ -38,6 +38,24 @@ Steps to apply this change:
             rm -rf $(BUILDDIR)/*
             # rm -f poetry.lock
 
+#. In the same file, remove the line ``$(POETRY) update`` fro the ``setup`` command:
+
+    .. code-block::
+
+        # Clean commands
+        .PHONY: clean
+        clean:
+            rm -rf $(BUILDDIR)/*
+            # rm -f poetry.lock
+
+
+#. In the same file, add a new separate command to update Python dependencies:
+
+    .. code-block::
+
+        .PHONY: update
+        update:
+            $(POETRY) update
 
 #. Add the following ``dependabot.yml`` configuration file in the ``.github`` directory:
 
@@ -85,6 +103,18 @@ Steps to apply this change:
         [build-system]
         requires = ["poetry>=1.8.0"]
         build-backend = "poetry.masonry.api" 
+
+#. Run the following command in the ``docs``folder to update the ``poetry.lock`` file:
+
+    .. code-block:: python
+
+        poetry lock --no-update
+
+#. Preview the docs. Ensure sure they render without errors:
+
+    .. code-block:: python
+
+        make preview
 
 #. Commit the changes to the repository, including the ``poetry.lock`` file.
 

--- a/docs/source/upgrade/1-7-to-1-8.rst
+++ b/docs/source/upgrade/1-7-to-1-8.rst
@@ -85,7 +85,7 @@ Steps to apply this change:
         [tool.poetry.dependencies]
         python = "^3.10"
         pygments = "^2.18.0"
-        sphinx-scylladb-theme = "^1.6.1"
+        sphinx-scylladb-theme = "^1.8.1"
         myst-parser = "^3.0.1"
         sphinx-autobuild = "^2024.4.19"
         Sphinx = "^7.3.7"

--- a/docs/source/upgrade/1-7-to-1-8.rst
+++ b/docs/source/upgrade/1-7-to-1-8.rst
@@ -38,18 +38,16 @@ Steps to apply this change:
             rm -rf $(BUILDDIR)/*
             # rm -f poetry.lock
 
-#. In the same file, remove the line ``$(POETRY) update`` fro the ``setup`` command:
+#. In the same file, remove the line ``$(POETRY) update`` from the ``setup`` command:
 
     .. code-block::
 
-        # Clean commands
-        .PHONY: clean
-        clean:
-            rm -rf $(BUILDDIR)/*
-            # rm -f poetry.lock
+        .PHONY: setup
+        setup:
+            $(POETRY) install
+            # $(POETRY) update
 
-
-#. In the same file, add a new separate command to update Python dependencies:
+#. In the same file, add a new command to update Python dependencies:
 
     .. code-block::
 


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/849#issuecomment-2381991595

Separates the update command from the setup command in the docs Makefile.

This separation is necessary because, starting with Sphinx ScyllaDB Theme version 1.8, the versions are no longer strictly pinned in the `pyproject.toml` file. This change ensures that the versions defined in the `poetry.lock` file (committed to the repository) are used for production builds.

## How to test

1. Build the docs locally using `make preview`.
2. Verify that the dependencies in the `poetry.lock` file remain unchanged.