### PR TITLE
fix: tooltip glossary priority

### DIFF
--- a/docs/source/examples/glossary.rst
+++ b/docs/source/examples/glossary.rst
@@ -18,6 +18,12 @@ The glossary has the following format:
       Term 2
          Definition
 
+      Long description
+         Lorem ipsum dolor sit amet, ``consectetur`` adipiscing elit. Ut tincidunt orci non pellentesque hendrerit. Sed vitae sem convallis, porta felis ut, varius libero. Suspendisse eget auctor felis. Sed sit amet sapien posuere, eleifend urna ut, interdum nisi.
+         Donec porta nibh leo, vitae convallis risus ornare sit amet. Mauris porttitor ipsum in mi dignissim, vel volutpat massa placerat.
+         
+         Vivamus et cursus turpis, id luctus lectus.
+
 This will result in:
 
 .. glossary::
@@ -29,7 +35,10 @@ This will result in:
       Definition
    
    Long description
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sed lorem quis dui mattis suscipit sit amet id dui. Suspendisse elementum rutrum vulputate. Cras in velit sapien. Etiam egestas turpis eget arcu feugiat semper. Ut blandit sagittis cursus. Maecenas at varius ex, et porttitor mi. Nullam tortor elit, tincidunt et nulla id, porta vestibulum nibh. Quisque tellus elit, maximus at congue quis, molestie eget urna. Donec odio lorem, semper sed pharetra eu, sodales eget velit. Donec dignissim quam mi, nec vehicula magna gravida in. Vestibulum consectetur, sem a tristique porta, risus est laoreet nibh, sed cursus nibh est vel massa. Vestibulum aliquet varius tellus eu pulvinar. Integer a lorem sollicitudin, placerat orci eu, lobortis velit. Pellentesque sit amet magna porta augue iaculis egestas dapibus sed dui.
+      Lorem ipsum dolor sit amet, ``consectetur`` adipiscing elit. Ut tincidunt orci non pellentesque hendrerit. Sed vitae sem convallis, porta felis ut, varius libero. Suspendisse eget auctor felis. Sed sit amet sapien posuere, eleifend urna ut, interdum nisi.
+      Donec porta nibh leo, vitae convallis risus ornare sit amet. Mauris porttitor ipsum in mi dignissim, vel volutpat massa placerat.
+      
+      Vivamus et cursus turpis, id luctus lectus.
 
 
 

--- a/docs/source/examples/tooltips.rst
+++ b/docs/source/examples/tooltips.rst
@@ -15,32 +15,38 @@ Syntax
 Usage
 -----
 
-Tooltip with text
-.................
+Tooltip with inline text
+........................
 
 Using:
 
 .. code-block:: rst
 
    Here is a :include_tooltip:`word <This is the tooltip text>`.
+   
+   Here is another :include_tooltip:`term with long description <Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut tincidunt orci non pellentesque hendrerit. Sed vitae sem convallis, porta felis ut, varius libero. Suspendisse eget auctor felis. Sed sit amet sapien posuere, eleifend urna ut, interdum nisi.>`.
 
 Results in:
 
 Here is a :include_tooltip:`word <This is the tooltip text>`.
 
+Here is another :include_tooltip:`term with long description <Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut tincidunt orci non pellentesque hendrerit. Sed vitae sem convallis, porta felis ut, varius libero. Suspendisse eget auctor felis. Sed sit amet sapien posuere, eleifend urna ut, interdum nisi.>`.
+
 Tooltip from a glossary entry
 .............................
+
+You can also create a tooltip by referencing a glossary term. The tooltip will automatically pull the term's definition from the glossary.
 
 Using:
 
 .. code-block:: rst
 
    Here is a :include_tooltip:`term <Term 1>`.
-
-This will load the definition of `term-name` from your project's glossary and use it as the tooltip text for "term".
-
+   
+   Here is another :include_tooltip:`term loading a long description <Long description>` from the glossary.
 
 Results in:
 
-Here is a :include_tooltip:`term <Term 1>`.
+Here is a :include_tooltip:`term <Term 1>` loading the description from the glossary.
 
+Here is another :include_tooltip:`term loading a long description <Long description>` from the glossary.

--- a/sphinx_scylladb_theme/extensions/include_tooltip.py
+++ b/sphinx_scylladb_theme/extensions/include_tooltip.py
@@ -6,6 +6,7 @@ that can either contain inline text or load terms from the glossary.
 from docutils import nodes
 from docutils.parsers.rst import roles
 from sphinx.util import logging
+from sphinx.transforms.post_transforms import SphinxPostTransform
 
 LOGGER = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ class include_tooltip_node(nodes.inline, nodes.Element):
     pass
 
 def visit_include_tooltip_node_html(self, node):
-    tooltip_text = node['tooltip']
+    tooltip_text = node.get('tooltip', '')
     self.body.append(
         f'<span data-tooltip data-tooltip-height="0" tabindex="1" title="{tooltip_text}" class="top">'
     )
@@ -21,32 +22,33 @@ def visit_include_tooltip_node_html(self, node):
 def depart_include_tooltip_node_html(self, node):
     self.body.append('</span>')
 
-def get_tooltip_from_glossary(tooltip_source, inliner):
-    env = inliner.document.settings.env
-    std_domain = env.get_domain('std')
-    glossary_terms = std_domain._terms
-    term_info = glossary_terms.get(tooltip_source.lower(), None)
-    if term_info:
-        docname, labelid = term_info
-        try:
-            doctree = env.get_doctree(docname)
-            term_node = doctree.ids.get(labelid)
+class TooltipPostTransform(SphinxPostTransform):
+    default_priority = 500 
 
-            if term_node and term_node.parent:
-                definition_node = None
-                for sibling in term_node.parent:
-                    if isinstance(sibling, nodes.definition):
-                        definition_node = sibling
-                        break
+    def apply(self, **kwargs):
+        env = self.env
+        std_domain = env.get_domain('std')
+        glossary_terms = std_domain._terms
 
-                if definition_node:
-                    return definition_node.astext()
-        except Exception as e:
-            pass
-    return None
+        for node in self.document.traverse(include_tooltip_node):
+            tooltip_source = node.get('tooltip_source', '').lower()
+            tooltip_text = node.get('tooltip_source', '')
 
-def get_tooltip_from_text(tooltip_source):
-    return tooltip_source
+            if tooltip_source in glossary_terms:
+                docname, labelid = glossary_terms[tooltip_source]
+                try:
+                    doctree = env.get_doctree(docname)
+                    term_node = doctree.ids.get(labelid)
+
+                    if term_node and term_node.parent:
+                        for sibling in term_node.parent:
+                            if isinstance(sibling, nodes.definition):
+                                tooltip_text = sibling.astext()
+                                break
+                except Exception as e:
+                    LOGGER.error(f"Error retrieving tooltip from glossary during post-transform: {e}")
+            
+            node['tooltip'] = tooltip_text
 
 def include_tooltip_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     if '<' in text and '>' in text:
@@ -56,25 +58,20 @@ def include_tooltip_role(name, rawtext, text, lineno, inliner, options={}, conte
         tooltip_source = text[start_index + 1:end_index].strip()
     else:
         msg = inliner.reporter.error(
-            "Invalid syntax for include_tooltip role. Expected format: 'display text <tooltip text or term or file>'",
+            "Invalid syntax for include_tooltip role. Expected format: 'display text <tooltip text or term>'",
             line=lineno
         )
         return [inliner.problematic(rawtext, rawtext, msg)], [msg]
 
-    tooltip_text = (
-        get_tooltip_from_glossary(tooltip_source, inliner) or
-        get_tooltip_from_text(tooltip_source)
-    )
-
-    
     node = include_tooltip_node(main_text, main_text)
-    node['tooltip'] = tooltip_text
-    
+    node['tooltip_source'] = tooltip_source
+
     return [node], []
 
 def setup(app):
     roles.register_local_role('include_tooltip', include_tooltip_role)
     app.add_node(include_tooltip_node, html=(visit_include_tooltip_node_html, depart_include_tooltip_node_html))
+    app.add_post_transform(TooltipPostTransform)
     
     return {
         'version': '1.0',

--- a/tests/extensions/test_include_tooltip.py
+++ b/tests/extensions/test_include_tooltip.py
@@ -41,5 +41,5 @@ def test_include_tooltip_role(role_name, input_text, expected_output, glossary, 
     node = result[0]
     assert isinstance(node, include_tooltip_node)
 
-    output_html = f'<span data-tooltip data-tooltip-height="0" tabindex="1" title="{node["tooltip"]}" class="top">{node.astext()}</span>'
+    output_html = f'<span data-tooltip data-tooltip-height="0" tabindex="1" title="{node["tooltip_source"]}" class="top">{node.astext()}</span>'
     assert bs(output_html, "html.parser").prettify() == bs(expected_output, "html.parser").prettify()


### PR DESCRIPTION
Related issue #873 

While integrating tooltips into the open-source project, I encountered an issue where the glossary entries were not loading consistently. This was due to their dependency on where the glossary entries were defined and whether Sphinx processed them before or after rendering the tooltips.

This pull request addresses the issue by adding placeholders for all tooltips. Once the glossary entries have been loaded, the placeholders are replaced with the correct values.

Additionally, I have included examples showing how longer tooltips with special characters are rendered.

### How to test

1. Build the documentation.
2. Go to the **Examples > Tooltips** page.
3. Verify that the examples render as expected.