### PR TITLE
docs/Makefile: work around python-poetry issue #8761

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # Global variables
 # You can set these variables from the command line.
-POETRY        = poetry
+POETRY        = PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry
 SPHINXOPTS    = -j auto
 SPHINXBUILD   = $(POETRY) run sphinx-build
 PAPER         =


### PR DESCRIPTION
Python-poetry is affected by bug
<https://github.com/python-poetry/poetry/issues/8761>. Namely, if you have "keyring" <https://pypi.org/project/keyring/> installed, poetry will try to gain access to the Default collection in the (ex. GNOME) keyring, even if poetry only needs read-only access to package repositories, and even if those repos are public.

Consequently, you either unlock your Default collection for poetry (unjustifiedly), or your GUI session gets effectively locked up, because any time you hit Cancel on the keyring unlock dialog, poetry immediately pops up another, and this dialog grabs the keyboard -- you cannot even switch to a character VT, for killing poetry; you have to log in via ssh for that.

This issue is not visible to users who don't use "keyring" (GNOME or otherwise). For those who do, work around the problem by selecting the "null" keyring back-end, in the environment of every poetry invocation.

Note: I have not regression-tested the workaround in a desktop environment where "keyring" is unavailable to begin with.