### PR TITLE
feat: add fetch_multiversion_configuration

### DIFF
--- a/sphinx_scylladb_theme/utils.py
+++ b/sphinx_scylladb_theme/utils.py
@@ -1,3 +1,6 @@
+import requests
+import json
+
 def multiversion_regex_builder(versions):
     """Generates a regex string from a list of versions.
 
@@ -20,3 +23,21 @@ def multiversion_regex_builder(versions):
     else:
         versions = [f"^{version}$" for version in versions]
         return r"\b(" + "|".join(versions) + r")\b"
+
+
+def fetch_multiversion_configuration(url):
+    """Fetches JSON content from the specified URL and parses it into a Python object
+    for defining ScyllaDB multiversion data from a remote source.
+
+    :param url: The URL to fetch the JSON data from.
+    :type url: str
+
+    :return: A dictionary representing the JSON content.
+    :rtype: dict
+    """
+    try:
+        response = requests.get(url)
+        return response.json()
+    except Exception as e:
+        print(f"Error fetching data from {url}: {e}")
+        return None

--- a/sphinx_scylladb_theme/utils.py
+++ b/sphinx_scylladb_theme/utils.py
@@ -37,6 +37,7 @@ def fetch_multiversion_configuration(url):
     """
     try:
         response = requests.get(url)
+        response.raise_for_status()
         return response.json()
     except Exception as e:
         print(f"Error fetching data from {url}: {e}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
-from sphinx_scylladb_theme.utils import multiversion_regex_builder
+from sphinx_scylladb_theme.utils import multiversion_regex_builder, fetch_multiversion_configuration
+from unittest.mock import patch, MagicMock
 
 
 def test_multiversion_regex_builder_empty():
@@ -19,3 +20,50 @@ def test_multiversion_regex_builder_one_version():
 def test_multiversion_regex_builder_many_version():
     versions = ["1.0", "2.0"]
     assert multiversion_regex_builder(versions) == r"\b(^1.0$|^2.0$)\b"
+
+def test_fetch_multiversion_configuration_success():
+    url = "https://example.com/success"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "tags": [],
+        "branches": ["master", "branch-5.1", "branch-5.2"],
+        "latest": "branch-5.2",
+    }
+    with patch("requests.get", return_value=mock_response):
+        result = fetch_multiversion_configuration(url)
+        assert result == {
+            "tags": [],
+            "branches": ["master", "branch-5.1", "branch-5.2"],
+            "latest": "branch-5.2",
+        }
+
+
+def test_fetch_multiversion_configuration_http_error():
+    url = "https://example.com/http_error"
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.HTTPError("HTTP Error")
+    with patch("requests.get", return_value=mock_response):
+        result = fetch_multiversion_configuration(url)
+        assert result is None
+
+
+def test_fetch_multiversion_configuration_invalid_json():
+    url = "https://example.com/invalid_json"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.side_effect = ValueError("Invalid JSON")
+    with patch("requests.get", return_value=mock_response):
+        result = fetch_multiversion_configuration(url)
+        assert result is None
+
+
+def test_fetch_multiversion_configuration_invalid_url():
+    result = fetch_multiversion_configuration(None)
+    assert result is None
+
+    result = fetch_multiversion_configuration("")
+    assert result is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import requests
 from sphinx_scylladb_theme.utils import multiversion_regex_builder, fetch_multiversion_configuration
 from unittest.mock import patch, MagicMock
 


### PR DESCRIPTION
Related issue: https://github.com/scylladb/scylladb-docs-homepage/pull/30

Adds a helper to get multiversion data from a remote URL.

To test the changes, we'll build multiple versions using data from the following URL:  
https://gist.github.com/dgarcia360/d18edbfac5e2fc1443ba0819840e2fd1  

```json
{
    "tags": [],
    "branches": ["master", "branch-1.8"],
    "latest": "branch-1.8",
    "unstable": ["master"],
    "deprecated": []
}
```

## How to test

1. Checkout master and branch-1.8 branches:

  ```bash
  git checkout branch-1.8
  git checkout master
  ```

2. Checkout this PR:

  ```bash
   gh pr checkout 1303
   ```
   
3. Edit `docs/conf.py`global variables section as follows:

  ```python
  VERSIONS_URL = "https://gist.githubusercontent.com/dgarcia360/d18edbfac5e2fc1443ba0819840e2fd1/raw/dcf460800849f5bc623982532edeb70499f0e3a9/gistfile1.json"
  MULTIVERSION_CONFIG = fetch_multiversion_configuration(VERSIONS_URL)
  # Builds documentation for the following tags and branches.
  TAGS = MULTIVERSION_CONFIG.get("tags", [])
  BRANCHES = MULTIVERSION_CONFIG.get("branches", [])
  # Sets the latest version.
  LATEST_VERSION = MULTIVERSION_CONFIG.get("latest", "master")
  # Set which versions are not released yet.
  UNSTABLE_VERSIONS = MULTIVERSION_CONFIG.get("unstable", [])
  # Set which versions are deprecated
  DEPRECATED_VERSIONS = MULTIVERSION_CONFIG.get("deprecated", [])
  # Sets custom build.
  FLAGS = ["theme"]
  ```

  This change will read configuration versions from an external file.

4. In the same `conf.py`, set `smv_remote_whitelist` to `None`:

  ```python
  smv_remote_whitelist = None
  ```

  This ensures the multiversion build considers only the local branches cloned in Step 1.


5. In the terminal, run the multiversion preview:

   ```
   make multiversionpreview
   ```
   
 6. Verify docs build with multiversion enabled. The `branch-1.8` version should be listed as available in the documentation.
 
 ## Next steps
 
 Release a new version of the theme and configure open-source and enterprise repo to read from remote files for multiversion config.