### PR TITLE
feat: override multiversion redirect

### DIFF
--- a/docs/source/configuration/template.rst
+++ b/docs/source/configuration/template.rst
@@ -38,7 +38,6 @@ Example:
       'scylladb_scripts': 'true',
   }
 
-
 Banner options
 --------------
 
@@ -315,3 +314,21 @@ Configuration options for enabling zendesk.
   html_theme_options = {
       'zendesk_tag': 'gq6ltsh3nfex3cnwfy4aj9',
   }
+
+
+Multiversion options
+--------------------
+
+.. list-table::
+  :widths: 20 20 20 40
+  :header-rows: 1
+
+  * - Option
+    - Type
+    - Default Value
+    - Description
+  * - ``redirect``
+    - string
+    - 
+    - Overrides the default redirection of the main domain when using multiversion. By default, it redirects to ``<DOMAIN>/stable/``. Overriding setting this can be useful if the main domain page publishes multiple documentation sets. Example: ``/manual/stable/``.
+

--- a/sphinx_scylladb_theme/extensions/multiversion.py
+++ b/sphinx_scylladb_theme/extensions/multiversion.py
@@ -80,10 +80,14 @@ def create_redirect_to_latest_version(app, exception):
         and app.config.smv_rename_latest_version
     ):
         latest_dir = app.config.smv_rename_latest_version
-
+    
+    theme_options = app.config.html_theme_options
+    custom_redirect = theme_options.get("redirect", "")
+    if custom_redirect:
+        latest_dir = custom_redirect
+    
     out_dir = Path(app.builder.outdir)
     head = out_dir.parent
-    theme_options = app.config.html_theme_options
     zendesk_tag = theme_options.get("zendesk_tag", "")
 
     with open(head / "index.html", "w+") as t_file:

--- a/sphinx_scylladb_theme/theme.conf
+++ b/sphinx_scylladb_theme/theme.conf
@@ -29,3 +29,4 @@ versions_deprecated=
 brand=product
 zendesk_tag=
 skip_warnings=
+redirect=


### PR DESCRIPTION
## Motivation

Adds an option to override the multiversion redirect for the main domain.

It is particularly useful for redirecting `docs.scylladb.com/manual` to `docs.scylladb.com/manual/stable` instead of `docs.scylladb.com/stable`.

## How to test

1. Open `docs/conf.py`.
2. Define a custom redirect in `html_theme_options` as follows:

    ```python
    html_theme_options = {
        "redirect": "/manual/stable",
    }
    ```

3. Build the documentation using `make multiversionpreview`.

4. Verify that `http://localhost:5500/` redirects to `/manual/stable` instead of `/stable`.
