### PR TITLE
rm: license alert

### DIFF
--- a/sphinx_scylladb_theme/alert.html
+++ b/sphinx_scylladb_theme/alert.html
@@ -1,4 +1,0 @@
-<div class="alert">
-    <div><i class="icon-logs"></i> We’re updating our license & versioning policy</div>
-    <div><a href="https://www.scylladb.com/2024/12/18/why-were-moving-to-a-source-available-license/" target="_blank">Learn more about the change <i class="icon-arrow-right"></i></a></div>
-</div>

--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -102,12 +102,6 @@
                 {% endif %}
 
                     <div class="content-body">
-                        {% if not hide_alert %}
-                        {% if 'opensource' in html_baseurl or 'enterprise' in html_baseurl %}
-                        {% include 'alert.html'%}
-                        {% endif %}
-                        {% endif %}
-    
                         {% if not hide_version_warning %}
                             {% include 'version-warning.html'%}
                         {% endif %}


### PR DESCRIPTION
Removes the "We’re updating our license & versioning policy" banner from internal pages.

## How to test

This is challenging to test since it wasn’t showing in this repo either.  You can verify that the banner appears on the landing page but not on internal pages after running `make preview`.





