### PR TITLE
Remove alert from homepage (docs theme)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,14 +26,6 @@
 
   <div class="topics-grid grid-container full">
 
-.. alert::
-  :link: https://www.scylladb.com/2024/12/18/why-were-moving-to-a-source-available-license/
-  :target: _blank
-  :link_text: Learn more about the change
-  :icon: logs
-
-   We’re updating our license & versioning policy
-
 .. raw:: html
 
   <div class="grid-x grid-margin-x">


### PR DESCRIPTION
Removes the alert on the theme docs landing (we added it for testing purposes):

![image](https://github.com/user-attachments/assets/d105995d-a1bf-40b3-a006-9e2dddb14f80)
