### PR TITLE
`sphinx-multiversion` compatibility with Python 3.13

### DIFF
--- a/extensions/sphinx-multiversion/requirements.txt
+++ b/extensions/sphinx-multiversion/requirements.txt
@@ -1,1 +1,3 @@
 sphinx
+
+looseversion

--- a/extensions/sphinx-multiversion/sphinx_multiversion/sphinx.py
+++ b/extensions/sphinx-multiversion/sphinx_multiversion/sphinx.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import posixpath
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 
 from sphinx import config as sphinx_config
 from sphinx.locale import _


### PR DESCRIPTION
The `distutils` package is deprecated in Python 3.13.

`sphinx-multiversion` used `LooseVersion` found in `distutils` to parse version names. This gave it flexibility to deal with versions that were not PEP-440 compliant.

This PR simply changes `distutils` with [`looseversion`](https://github.com/effigies/looseversion), which attempts to be a drop-in replacement for this functionality.