### PR TITLE
feat: define myst_substitutions per version

### DIFF
--- a/extensions/sphinx-multiversion/README.md
+++ b/extensions/sphinx-multiversion/README.md
@@ -58,6 +58,7 @@ See https://github.com/scylladb/sphinx-scylladb-theme/pull/891
 The following properties can be defined on a per-version basis.
 
 * `rst_prolog`
+* `myst_substitutions`: Introduced in 0.3.3
 * `exclude_patterns`: Introduced in 0.3.2
 
 ## License

--- a/extensions/sphinx-multiversion/setup.py
+++ b/extensions/sphinx-multiversion/setup.py
@@ -21,7 +21,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.3.2",
+    version="0.3.3",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/extensions/sphinx-multiversion/sphinx_multiversion/__init__.py
+++ b/extensions/sphinx-multiversion/sphinx_multiversion/__init__.py
@@ -2,7 +2,7 @@
 from .main import main
 from .sphinx import setup
 
-__version__ = "0.3.1"
+__version__ = "0.3.3"
 
 __all__ = [
     "setup",

--- a/extensions/sphinx-multiversion/sphinx_multiversion/main.py
+++ b/extensions/sphinx-multiversion/sphinx_multiversion/main.py
@@ -308,11 +308,15 @@ def main(argv=None):
 
             current_sourcedir = os.path.join(repopath, sourcedir)
             project = sphinx_project.Project(current_sourcedir, source_suffixes)
+            
+            myst_substitutions = getattr(current_config, 'myst_substitutions', {})
+            
             metadata[gitref.name] = {
                 "name": gitref.name,
                 "version": current_config.version,
                 "release": current_config.release,
                 "rst_prolog": current_config.rst_prolog,
+                "myst_substitutions": myst_substitutions,
                 "exclude_patterns": current_config.exclude_patterns,
                 "is_released": bool(
                     re.match(config.smv_released_pattern, gitref.refname)

--- a/extensions/sphinx-multiversion/sphinx_multiversion/sphinx.py
+++ b/extensions/sphinx-multiversion/sphinx_multiversion/sphinx.py
@@ -181,6 +181,7 @@ def config_inited(app, config):
     config.version = data["version"]
     config.release = data["release"]
     config.rst_prolog = data["rst_prolog"]
+    config.myst_substitutions = data["myst_substitutions"]
     config.exclude_patterns = data["exclude_patterns"]
     config.today = old_config.today
     if not config.today:


### PR DESCRIPTION
Allow defining `myst_substitutions` per branch or version instead of falling back to the default branch values.

This follows a similar approach to the `rst_prolog` variable, but applied to Myst.

## How to test

Tested locally, though it’s tricky to reproduce. The steps are:
1. Replace the PyPI extension with the local extension.
2. Define myst_substitutions variable with different values in multiple branches.
3. Run multiversion.

## Next steps

After merging, I will release a new version of the extension.