### PR TITLE
fix: sort multiversion dropdown

### DIFF
--- a/extensions/sphinx-multiversion/setup.py
+++ b/extensions/sphinx-multiversion/setup.py
@@ -21,7 +21,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.3.7",
+    version="0.3.8",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/extensions/sphinx-multiversion/sphinx_multiversion/__init__.py
+++ b/extensions/sphinx-multiversion/sphinx_multiversion/__init__.py
@@ -2,7 +2,7 @@
 from .main import main
 from .sphinx import setup
 
-__version__ = "0.3.4"
+__version__ = "0.3.8"
 
 __all__ = [
     "setup",

--- a/extensions/sphinx-multiversion/sphinx_multiversion/sphinx.py
+++ b/extensions/sphinx-multiversion/sphinx_multiversion/sphinx.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 
 from packaging.version import InvalidVersion
 from packaging.version import Version as PkgVersion
@@ -14,6 +15,13 @@ def _version_key(v):
     try:
         return (0, PkgVersion(v.name))
     except InvalidVersion:
+        # Try to extract a version number from the name (e.g., "branch-4.9" -> "4.9")
+        match = re.search(r"(\d+(?:\.\d+)+)", v.name)
+        if match:
+            try:
+                return (0, PkgVersion(match.group(1)))
+            except InvalidVersion:
+                pass
         return (1, v.name)
 
 from sphinx import config as sphinx_config


### PR DESCRIPTION
Fix multiversion sort order in ScyllaDB Monitoring.

Tested locally:

<img width="391" height="786" alt="image" src="https://github.com/user-attachments/assets/65e9502c-a75a-42c6-9de9-c1635a58d052" />

## Next steps

I'll release a new version of the multiversion extension and install it in the monitoring repository.