### PR TITLE
chore: ensure compat with node 24

### DIFF
--- a/.github/workflows/frontend-tests.yaml
+++ b/.github/workflows/frontend-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/source/contribute/contribute-theme.rst
+++ b/docs/source/contribute/contribute-theme.rst
@@ -57,7 +57,7 @@ The original static files are located under the folder ``src``.
 
 To build the minimized static files for this project:
 
-#.  Make sure you have Node.js 18 or later installed.
+#.  Make sure you have Node.js 20 or later installed.
 #.  Build the static files with:
 
 .. code:: console

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "turndown-plugin-gfm": "^1.0.2"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
Bumps minimum Node.js version to 20 and ensures the theme is compatible with Node.js 24 by adding it to the `frontend-test`workflow.

## How to test

Node.js 24 test passes: https://github.com/scylladb/sphinx-scylladb-theme/actions/runs/25857250799/job/75978067594?pr=1624