### PR TITLE
feat: add diagram directive

### DIFF
--- a/docs/source/examples/diagrams.rst
+++ b/docs/source/examples/diagrams.rst
@@ -3,7 +3,10 @@ Diagrams
 
 The documentation toolchain supports rendering diagrams and charts using `Mermaid <https://mermaid.js.org/intro/>`_, a library designed for creating sequence diagrams, flowcharts, and other visualizations.
 
-Using:
+Default
+-------
+
+Use the ``mermaid`` directive to render a diagram inline.
 
 .. code-block:: python
 
@@ -22,3 +25,40 @@ Renders:
    B -- Label --> C
 
 For more details, refer to the `sphinxcontrib-mermaid <https://sphinxcontrib-mermaid-demo.readthedocs.io/en/latest/>`_ documentation.
+
+Diagrams with metadata
+----------------------
+
+Mermaid diagrams can be wrapped with the ``diagram`` directive to attach metadata, so external tools can filter and extract them.
+
+.. code-block:: none
+
+   .. diagram::
+      :id: request-flow
+      :tags: networking, ingress
+      :categories: architecture
+      :deployment: core
+      :last-reviewed: 2026-06-01
+
+      .. mermaid::
+
+         graph TD
+         Client --> Gateway
+         Gateway -- Auth --> Service
+         Service --> Database
+
+Renders:
+
+.. diagram::
+   :id: request-flow
+   :tags: networking, ingress
+   :categories: architecture
+   :deployment: core
+   :last-reviewed: 2026-06-01
+
+   .. mermaid::
+
+      graph TD
+      Client --> Gateway
+      Gateway -- Auth --> Service
+      Service --> Database

--- a/docs/source/examples/images.rst
+++ b/docs/source/examples/images.rst
@@ -1,21 +1,26 @@
 Images
 ======
 
-There are two possible directives for images. One is the image directive and the other is the figure directive.
+There are two possible directives for images: the image directive and the figure directive.
 Refer to `DocUtils <https://docutils.sourceforge.io/docs/ref/rst/directives.html#images>`_ for more options.
+
+Image directive
+---------------
 
 .. code-block:: none
 
   .. image:: images/checkmark.png
       :alt: checkmark
 
-renders the image
+Renders the image:
 
 .. image:: images/checkmark.png
    :alt: checkmark
 
+Figure directive
+----------------
 
-Whereas the figure directive allows you to use captions.
+The figure directive allows you to use captions.
 
 .. code-block:: none
 
@@ -57,3 +62,38 @@ Renders the image as:
    :width: 150px
 
 Click on the image to preview it in full size.
+
+Diagrams with metadata
+----------------------
+
+Use the ``diagram`` directive to wrap a figure or image with metadata so external tools can filter and extract diagrams.
+The ``:id:`` option becomes the wrapper's HTML ``id`` attribute.
+The remaining options are exposed as ``data-*`` attributes on the wrapping ``<div class="diagram">``.
+
+.. code-block:: none
+
+   .. diagram::
+      :id: auth-flow
+      :tags: networking, security
+      :categories: security
+      :deployment: core
+      :last-reviewed: 2026-06-01
+
+      .. figure:: images/diagram.svg
+         :alt: Authentication flow
+
+         Authentication flow diagram.
+
+Renders as:
+
+.. diagram::
+   :id: auth-flow
+   :tags: networking, security
+   :categories: security
+   :deployment: core
+   :last-reviewed: 2026-06-01
+
+   .. figure:: images/diagram.svg
+      :alt: Authentication flow
+
+      Authentication flow diagram.

--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -10,6 +10,7 @@ from sphinxcontrib import mermaid
 from sphinx_scylladb_theme._version import version
 from sphinx_scylladb_theme.extensions import (
     alerts,
+    diagram,
     grid,
     hero_box,
     include_tooltip,
@@ -154,6 +155,7 @@ def setup(app):
 
     """Setup custom extensions"""
     alerts.setup(app)
+    diagram.setup(app)
     hero_box.setup(app)
     grid.setup(app)
     include_tooltip.setup(app)

--- a/sphinx_scylladb_theme/extensions/diagram.py
+++ b/sphinx_scylladb_theme/extensions/diagram.py
@@ -1,0 +1,81 @@
+"""
+Sphinx directive that wraps a figure or image with metadata so external
+tools can filter and extract diagrams.
+
+Usage::
+
+    .. diagram::
+       :id: auth-flow
+       :tags: networking, security
+       :categories: security
+       :deployment: core
+       :last-reviewed: 2026-06-01
+
+       .. figure:: images/auth-flow.png
+          :alt: Authentication flow
+
+          Authentication flow diagram.
+
+The wrapped content is rendered inside a ``<div class="diagram">``. The
+``id`` option becomes the element ``id`` attribute, and the remaining
+options are exposed as ``data-*`` attributes.
+Comma-separated values in ``tags`` and ``categories`` are normalized
+(whitespace trimmed).
+"""
+
+import html
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+
+
+def _comma_list(argument):
+    if not argument:
+        return ""
+    parts = [p.strip() for p in argument.split(",") if p.strip()]
+    return ",".join(parts)
+
+
+class Diagram(Directive):
+    has_content = True
+    option_spec = {
+        "id": directives.unchanged,
+        "tags": _comma_list,
+        "categories": _comma_list,
+        "deployment": directives.unchanged,
+        "last-reviewed": directives.unchanged,
+    }
+
+    def run(self):
+        attrs = []
+        diagram_id = self.options.get("id", "").strip()
+        if diagram_id:
+            attrs.append(f'id="{html.escape(diagram_id, quote=True)}"')
+        for key in ("tags", "categories", "deployment", "last-reviewed"):
+            value = self.options.get(key, "").strip()
+            if value:
+                attrs.append(f'data-{key}="{html.escape(value, quote=True)}"')
+
+        attr_str = (" " + " ".join(attrs)) if attrs else ""
+        open_html = f'<div class="diagram"{attr_str}>'
+        close_html = "</div>"
+
+        content_node = nodes.container()
+        if self.state and self.content:
+            self.state.nested_parse(self.content, self.content_offset, content_node)
+
+        return [
+            nodes.raw(text=open_html, format="html"),
+            content_node,
+            nodes.raw(text=close_html, format="html"),
+        ]
+
+
+def setup(app):
+    app.add_directive("diagram", Diagram)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -12,9 +12,7 @@
         {% endfor %}
     {% endmacro %}
     {% macro css() %}
-        {% if theme_search_engine|lower == 'expertrec' %}
-            <link rel="dns-prefetch" href="https://cse.expertrec.com">
-        {% endif %}
+        {% include 'search-engine.html' %}
 
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link rel="preload" as="style"

--- a/sphinx_scylladb_theme/scylladb-scripts.html
+++ b/sphinx_scylladb_theme/scylladb-scripts.html
@@ -1,6 +1,8 @@
 <!-- Google Tag Manager docs -->
 <script>
     (function (w, d, s, l, i) {
+        var h = w.location.hostname;
+        if (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0' || h === '') return;
         w[l] = w[l] || [];
         w[l].push({
             "gtm.start": new Date().getTime(),
@@ -19,6 +21,8 @@
 <!-- Google Tag Manager global -->
 <script>
     (function (w, d, s, l, i) {
+        var h = w.location.hostname;
+        if (h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0' || h === '') return;
         w[l] = w[l] || [];
         w[l].push({
             "gtm.start": new Date().getTime(),
@@ -33,17 +37,3 @@
     })(window, document, "script", "dataLayer", "GTM-T8P2JP");
 </script>
 <!-- End Google Tag Manager -->
-
-<!-- Expertrec -->
-{% if theme_search_engine|lower == 'expertrec' %}
-    <script>
-        var id = "e2077224-9ccf-11e9-a0c9-0242ac130002";
-        var ci_search = document.createElement("script");
-        ci_search.type = "text/javascript";
-        ci_search.async = true;
-        ci_search.src = "https://cse.expertrec.com/api/js/ci_common.js?id=" + id;
-        var s = document.getElementsByTagName("script")[0];
-        s.parentNode.insertBefore(ci_search, s);
-    </script>
-{% endif %}
-<!-- End Expertrec -->

--- a/sphinx_scylladb_theme/search-engine.html
+++ b/sphinx_scylladb_theme/search-engine.html
@@ -1,0 +1,13 @@
+{# Search-engine-specific markup (dns-prefetch + bootstrap script). #}
+{% if theme_search_engine|lower == 'expertrec' %}
+    <link rel="dns-prefetch" href="https://cse.expertrec.com">
+    <script>
+        var id = "e2077224-9ccf-11e9-a0c9-0242ac130002";
+        var ci_search = document.createElement("script");
+        ci_search.type = "text/javascript";
+        ci_search.async = true;
+        ci_search.src = "https://cse.expertrec.com/api/js/ci_common.js?id=" + id;
+        var s = document.getElementsByTagName("script")[0];
+        s.parentNode.insertBefore(ci_search, s);
+    </script>
+{% endif %}

--- a/tests/extensions/test_diagram.py
+++ b/tests/extensions/test_diagram.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock
+
+import pytest
+from bs4 import BeautifulSoup as bs
+
+from sphinx_scylladb_theme.extensions.diagram import Diagram, _comma_list
+
+test_data = [
+    [
+        # All metadata options.
+        [],
+        {
+            "id": "auth-flow",
+            "tags": "networking,security",
+            "categories": "security",
+            "deployment": "core",
+            "last-reviewed": "2026-06-01",
+        },
+        ["placeholder"],
+        '<div class="diagram" id="auth-flow"'
+        ' data-tags="networking,security"'
+        ' data-categories="security"'
+        ' data-deployment="core"'
+        ' data-last-reviewed="2026-06-01">',
+        "</div>",
+    ],
+    [
+        # No options: bare wrapper, no attributes beyond the class.
+        [],
+        {},
+        ["placeholder"],
+        '<div class="diagram">',
+        "</div>",
+    ],
+    [
+        # Only :id: set.
+        [],
+        {"id": "diagram-1"},
+        ["placeholder"],
+        '<div class="diagram" id="diagram-1">',
+        "</div>",
+    ],
+    [
+        # HTML-special characters in option values are escaped.
+        [],
+        {"id": 'a"b', "tags": "<x>"},
+        ["placeholder"],
+        '<div class="diagram" id="a&quot;b" data-tags="&lt;x&gt;">',
+        "</div>",
+    ],
+]
+
+mock_state_machine = Mock()
+mock_state_machine.reporter = Mock()
+mock_state = Mock()
+
+
+@pytest.mark.parametrize(
+    "arguments, options, content, expected_open, expected_close", test_data
+)
+def test_diagram_wrapper(arguments, options, content, expected_open, expected_close):
+    directive = Diagram(
+        "diagram",
+        arguments,
+        options,
+        content,
+        0,
+        0,
+        "",
+        mock_state_machine,
+        mock_state,
+    )
+    result = directive.run()
+    assert len(result) == 3
+    assert bs(result[0].astext(), "html.parser") == bs(expected_open, "html.parser")
+    assert bs(result[2].astext(), "html.parser") == bs(expected_close, "html.parser")
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("networking, security", "networking,security"),
+        ("  a , b ,c  ", "a,b,c"),
+        ("a,,b", "a,b"),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_comma_list_normalizes_values(raw, expected):
+    assert _comma_list(raw) == expected


### PR DESCRIPTION
Closes #1642 

## How to test

1. Run `make preview`.
2. Open http://127.0.0.1:5500/examples/diagrams/ and http://127.0.0.1:5500/examples/images/
3. Check the diagram/image loaded with the `diagram` directive. If you inspect the code, it should render wrapped in a div with all the information passed to the directive as "data" options:

<img width="1125" height="234" alt="image" src="https://github.com/user-attachments/assets/bcd390d7-8d08-47f7-9d9e-ce039e402625" />


