### PR TITLE
feat: publish diagrams.json

### DIFF
--- a/docs/source/examples/diagrams.rst
+++ b/docs/source/examples/diagrams.rst
@@ -62,3 +62,40 @@ Renders:
       Client --> Gateway
       Gateway -- Auth --> Service
       Service --> Database
+
+Diagram catalog
+---------------
+
+Every ``diagram`` directive on the site is also indexed in a single ``diagrams.json`` published at the build root (e.g. ``https://sphinx-theme.scylladb.com/stable/diagrams.json``).
+Each entry carries the metadata plus either an absolute image URL or the raw mermaid source, so external tools can filter and extract diagrams without scraping HTML.
+
+Example entries with one mermaid diagram and one :doc:`image <images>`, illustrating both ``type`` values:
+
+.. code-block:: json
+
+   {
+     "diagrams": [
+       {
+         "id": "request-flow",
+         "page": "examples/diagrams",
+         "page_url": "https://sphinx-theme.scylladb.com/stable/examples/diagrams/#request-flow",
+         "tags": ["networking", "ingress"],
+         "categories": ["architecture"],
+         "deployment": "core",
+         "last_reviewed": "2026-06-01",
+         "type": "mermaid",
+         "content": "graph TD\nClient --> Gateway\nGateway -- Auth --> Service\nService --> Database"
+       },
+       {
+         "id": "auth-flow",
+         "page": "examples/images",
+         "page_url": "https://sphinx-theme.scylladb.com/stable/examples/images/#auth-flow",
+         "tags": ["networking", "security"],
+         "categories": ["security"],
+         "deployment": "core",
+         "last_reviewed": "2026-06-01",
+         "type": "image",
+         "content": "https://sphinx-theme.scylladb.com/stable/_images/diagram.svg"
+       }
+     ]
+   }

--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -21,6 +21,7 @@ from sphinx_scylladb_theme.extensions import (
     topic_box,
     validations,
 )
+from sphinx_scylladb_theme.extensions.utils import base_url
 from sphinx_scylladb_theme.lexers import cql, ditaa
 
 
@@ -99,18 +100,9 @@ def override_llms_txt_defaults(config):
 
     # Emit absolute URLs in llms.txt sitemaps, including the per-version
     # prefix when sphinx-multiversion is driving the build.
-    base_url = (getattr(config, "html_baseurl", "") or "").rstrip("/")
-    if not base_url:
-        return
-
-    sphinx_mv_outdir = getenv("SPHINX_MULTIVERSION_OUTPUTDIR")
-    if sphinx_mv_outdir:
-        version_slug = path.basename(sphinx_mv_outdir.rstrip("/"))
-        if version_slug:
-            base_url = f"{base_url}/{version_slug}"
-
-    if not getattr(config, "markdown_http_base", ""):
-        config.markdown_http_base = base_url
+    site_base = base_url(config)
+    if site_base and not getattr(config, "markdown_http_base", ""):
+        config.markdown_http_base = site_base
 
 
 def override_rst_epilog(config):

--- a/sphinx_scylladb_theme/extensions/diagram.py
+++ b/sphinx_scylladb_theme/extensions/diagram.py
@@ -1,6 +1,6 @@
 """
-Sphinx directive that wraps a figure or image with metadata so external
-tools can filter and extract diagrams.
+Sphinx directive that wraps a figure, image, or mermaid block with
+metadata so external tools can filter and extract diagrams.
 
 Usage::
 
@@ -19,14 +19,24 @@ Usage::
 The wrapped content is rendered inside a ``<div class="diagram">``. The
 ``id`` option becomes the element ``id`` attribute, and the remaining
 options are exposed as ``data-*`` attributes.
-Comma-separated values in ``tags`` and ``categories`` are normalized
-(whitespace trimmed).
+
+The extension also emits ``diagrams.json`` at the root of the build
+output. Each entry contains the metadata plus either an absolute image
+URL (``type: "image"``) or the raw mermaid source (``type: "mermaid"``).
 """
 
 import html
+import json
+import os
+from pathlib import Path
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+
+from .utils import base_url
+
+_DATA_KEYS = ("tags", "categories", "deployment", "last-reviewed")
+_HTML_BUILDERS = {"html", "dirhtml"}
 
 
 def _comma_list(argument):
@@ -34,6 +44,31 @@ def _comma_list(argument):
         return ""
     parts = [p.strip() for p in argument.split(",") if p.strip()]
     return ",".join(parts)
+
+
+def _split(value):
+    return [p for p in (value or "").split(",") if p]
+
+
+class diagram_node(nodes.General, nodes.Element):
+    """Doctree node carrying a wrapped diagram and its metadata."""
+
+
+def visit_diagram_html(self, node):
+    attrs = []
+    diagram_id = node.get("diagram_id", "")
+    if diagram_id:
+        attrs.append(f'id="{html.escape(diagram_id, quote=True)}"')
+    for key in _DATA_KEYS:
+        value = node.get(key, "")
+        if value:
+            attrs.append(f'data-{key}="{html.escape(value, quote=True)}"')
+    attr_str = (" " + " ".join(attrs)) if attrs else ""
+    self.body.append(f'<div class="diagram"{attr_str}>')
+
+
+def depart_diagram_html(self, node):
+    self.body.append("</div>")
 
 
 class Diagram(Directive):
@@ -47,35 +82,114 @@ class Diagram(Directive):
     }
 
     def run(self):
-        attrs = []
-        diagram_id = self.options.get("id", "").strip()
-        if diagram_id:
-            attrs.append(f'id="{html.escape(diagram_id, quote=True)}"')
-        for key in ("tags", "categories", "deployment", "last-reviewed"):
-            value = self.options.get(key, "").strip()
-            if value:
-                attrs.append(f'data-{key}="{html.escape(value, quote=True)}"')
+        node = diagram_node()
+        node["diagram_id"] = self.options.get("id", "").strip()
+        for key in _DATA_KEYS:
+            node[key] = self.options.get(key, "").strip()
 
-        attr_str = (" " + " ".join(attrs)) if attrs else ""
-        open_html = f'<div class="diagram"{attr_str}>'
-        close_html = "</div>"
-
-        content_node = nodes.container()
         if self.state and self.content:
-            self.state.nested_parse(self.content, self.content_offset, content_node)
+            self.state.nested_parse(self.content, self.content_offset, node)
 
-        return [
-            nodes.raw(text=open_html, format="html"),
-            content_node,
-            nodes.raw(text=close_html, format="html"),
-        ]
+        return [node]
+
+
+def _page_url(app, docname, anchor=""):
+    base = base_url(app.config)
+    builder = app.builder.name if app.builder is not None else ""
+    suffix = "/" if builder == "dirhtml" else ".html"
+    if docname == "index":
+        path = ""
+        suffix = ""
+    elif docname.endswith("/index"):
+        path = docname[: -len("index")]
+        suffix = ""
+    else:
+        path = docname
+    page = f"{base}/{path}{suffix}" if base else f"{path}{suffix}"
+    if anchor:
+        page = f"{page}#{anchor}"
+    return page
+
+
+def _image_url(app, uri):
+    base = base_url(app.config)
+    if not uri:
+        return None
+    if uri.startswith(("http://", "https://", "data:")):
+        return uri
+    if uri.startswith("_images/"):
+        served = uri
+    else:
+        mapped = getattr(app.env, "images", {}).get(uri)
+        if mapped:
+            served = f"_images/{mapped[1]}"
+        else:
+            served = f"_images/{os.path.basename(uri)}"
+    return f"{base}/{served}" if base else f"/{served}"
+
+
+def _is_mermaid(node):
+    return node.__class__.__name__ == "mermaid"
+
+
+def _extract_entry(app, docname, node):
+    diagram_id = node.get("diagram_id") or None
+    entry = {
+        "id": diagram_id,
+        "page": docname,
+        "page_url": _page_url(app, docname, anchor=diagram_id or ""),
+        "tags": _split(node.get("tags", "")),
+        "categories": _split(node.get("categories", "")),
+        "deployment": node.get("deployment") or None,
+        "last_reviewed": node.get("last-reviewed") or None,
+    }
+
+    for child in node.traverse():
+        if _is_mermaid(child):
+            entry["type"] = "mermaid"
+            entry["content"] = child.get("code", "")
+            return entry
+
+    for img in node.traverse(nodes.image):
+        entry["type"] = "image"
+        entry["content"] = _image_url(app, img.get("uri", ""))
+        return entry
+
+    return None
+
+
+def write_diagrams_json(app, exception):
+    if exception is not None:
+        return
+    if app.builder is None or app.builder.name not in _HTML_BUILDERS:
+        return
+
+    all_entries = []
+    env = app.env
+    for docname in sorted(env.found_docs):
+        try:
+            doctree = env.get_doctree(docname)
+        except Exception:
+            continue
+        for node in doctree.traverse(diagram_node):
+            entry = _extract_entry(app, docname, node)
+            if entry is not None:
+                all_entries.append(entry)
+
+    out_path = Path(app.builder.outdir) / "diagrams.json"
+    out_path.write_text(
+        json.dumps({"diagrams": all_entries}, indent=2, sort_keys=False),
+        encoding="utf-8",
+    )
 
 
 def setup(app):
+    app.add_node(diagram_node, html=(visit_diagram_html, depart_diagram_html))
     app.add_directive("diagram", Diagram)
+    app.connect("build-finished", write_diagrams_json)
 
     return {
-        "version": "0.1",
+        "version": "0.2",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/sphinx_scylladb_theme/extensions/multiversion.py
+++ b/sphinx_scylladb_theme/extensions/multiversion.py
@@ -9,7 +9,7 @@ Extends sphinx_multiversion:
 import os
 from pathlib import Path
 
-from .utils import build_redirect_body, copy
+from .utils import build_redirect_body, copy, latest_version_slug
 
 # Builders that produce the canonical site output. Other builders (e.g. the
 # ``markdown`` sub-build spawned by sphinx-llm) inherit
@@ -94,12 +94,7 @@ def add_root_seo_files_support(app, exception):
     :type exception: sphinx.error.SphinxError
     """
 
-    latest_dir = app.config.smv_latest_version
-    if (
-        hasattr(app.config, "smv_rename_latest_version")
-        and app.config.smv_rename_latest_version
-    ):
-        latest_dir = app.config.smv_rename_latest_version
+    latest_dir = latest_version_slug(app.config)
 
     out_dir = Path(app.builder.outdir)
     if out_dir.name != latest_dir:
@@ -125,12 +120,7 @@ def create_redirect_to_latest_version(app, exception):
     if not _is_primary_html_build(app):
         return
 
-    latest_dir = app.config.smv_latest_version
-    if (
-        hasattr(app.config, "smv_rename_latest_version")
-        and app.config.smv_rename_latest_version
-    ):
-        latest_dir = app.config.smv_rename_latest_version
+    latest_dir = latest_version_slug(app.config)
 
     theme_options = app.config.html_theme_options
     custom_redirect = theme_options.get("redirect", "")

--- a/sphinx_scylladb_theme/extensions/utils.py
+++ b/sphinx_scylladb_theme/extensions/utils.py
@@ -71,6 +71,44 @@ def build_redirect_body(path, zendesk_tag=""):
     return html
 
 
+def version_slug():
+    """
+    Returns the sphinx-multiversion path segment for the current build,
+    e.g. ``"stable"`` or ``"branch-1.9"``, or ``""`` outside multiversion.
+    """
+    sphinx_mv_outdir = os.getenv("SPHINX_MULTIVERSION_OUTPUTDIR")
+    if not sphinx_mv_outdir:
+        return ""
+    return os.path.basename(sphinx_mv_outdir.rstrip("/"))
+
+
+def base_url(config):
+    """
+    Returns the project's absolute ``html_baseurl`` with the
+    sphinx-multiversion path segment appended when running under
+    multiversion. Empty string when ``html_baseurl`` is unset.
+    """
+    base = (getattr(config, "html_baseurl", "") or "").rstrip("/")
+    if not base:
+        return ""
+    slug = version_slug()
+    if slug:
+        base = f"{base}/{slug}"
+    return base
+
+
+def latest_version_slug(config):
+    """
+    Returns the directory name of the latest stable version
+    (``smv_rename_latest_version`` if set, falling back to
+    ``smv_latest_version``). Empty string when neither is configured.
+    """
+    rename = getattr(config, "smv_rename_latest_version", None)
+    if rename:
+        return rename
+    return getattr(config, "smv_latest_version", "") or ""
+
+
 def is_url(path):
     """
     Checks if a path is an external url or a relative path.

--- a/tests/extensions/test_diagram.py
+++ b/tests/extensions/test_diagram.py
@@ -1,79 +1,104 @@
+import json
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
-from bs4 import BeautifulSoup as bs
 
-from sphinx_scylladb_theme.extensions.diagram import Diagram, _comma_list
-
-test_data = [
-    [
-        # All metadata options.
-        [],
-        {
-            "id": "auth-flow",
-            "tags": "networking,security",
-            "categories": "security",
-            "deployment": "core",
-            "last-reviewed": "2026-06-01",
-        },
-        ["placeholder"],
-        '<div class="diagram" id="auth-flow"'
-        ' data-tags="networking,security"'
-        ' data-categories="security"'
-        ' data-deployment="core"'
-        ' data-last-reviewed="2026-06-01">',
-        "</div>",
-    ],
-    [
-        # No options: bare wrapper, no attributes beyond the class.
-        [],
-        {},
-        ["placeholder"],
-        '<div class="diagram">',
-        "</div>",
-    ],
-    [
-        # Only :id: set.
-        [],
-        {"id": "diagram-1"},
-        ["placeholder"],
-        '<div class="diagram" id="diagram-1">',
-        "</div>",
-    ],
-    [
-        # HTML-special characters in option values are escaped.
-        [],
-        {"id": 'a"b', "tags": "<x>"},
-        ["placeholder"],
-        '<div class="diagram" id="a&quot;b" data-tags="&lt;x&gt;">',
-        "</div>",
-    ],
-]
+from sphinx_scylladb_theme.extensions.diagram import (
+    Diagram,
+    _comma_list,
+    _image_url,
+    _page_url,
+    _split,
+    depart_diagram_html,
+    diagram_node,
+    visit_diagram_html,
+)
 
 mock_state_machine = Mock()
 mock_state_machine.reporter = Mock()
 mock_state = Mock()
 
 
-@pytest.mark.parametrize(
-    "arguments, options, content, expected_open, expected_close", test_data
-)
-def test_diagram_wrapper(arguments, options, content, expected_open, expected_close):
-    directive = Diagram(
+def _build_directive(options):
+    return Diagram(
         "diagram",
-        arguments,
+        [],
         options,
-        content,
+        ["placeholder"],
         0,
         0,
         "",
         mock_state_machine,
         mock_state,
     )
+
+
+def test_directive_returns_single_diagram_node_with_metadata():
+    directive = _build_directive(
+        {
+            "id": "auth-flow",
+            "tags": "networking,security",
+            "categories": "security",
+            "deployment": "core",
+            "last-reviewed": "2026-06-01",
+        }
+    )
     result = directive.run()
-    assert len(result) == 3
-    assert bs(result[0].astext(), "html.parser") == bs(expected_open, "html.parser")
-    assert bs(result[2].astext(), "html.parser") == bs(expected_close, "html.parser")
+    assert len(result) == 1
+    node = result[0]
+    assert isinstance(node, diagram_node)
+    assert node["diagram_id"] == "auth-flow"
+    assert node["tags"] == "networking,security"
+    assert node["categories"] == "security"
+    assert node["deployment"] == "core"
+    assert node["last-reviewed"] == "2026-06-01"
+
+
+def test_directive_returns_node_with_empty_metadata_when_no_options():
+    result = _build_directive({}).run()
+    node = result[0]
+    assert isinstance(node, diagram_node)
+    assert node["diagram_id"] == ""
+    assert all(
+        node[k] == "" for k in ("tags", "categories", "deployment", "last-reviewed")
+    )
+
+
+@pytest.mark.parametrize(
+    "options, expected_open",
+    [
+        (
+            {
+                "id": "auth-flow",
+                "tags": "networking,security",
+                "categories": "security",
+                "deployment": "core",
+                "last-reviewed": "2026-06-01",
+            },
+            '<div class="diagram" id="auth-flow"'
+            ' data-tags="networking,security"'
+            ' data-categories="security"'
+            ' data-deployment="core"'
+            ' data-last-reviewed="2026-06-01">',
+        ),
+        ({}, '<div class="diagram">'),
+        ({"id": "diagram-1"}, '<div class="diagram" id="diagram-1">'),
+        (
+            {"id": 'a"b', "tags": "<x>"},
+            '<div class="diagram" id="a&quot;b" data-tags="&lt;x&gt;">',
+        ),
+    ],
+)
+def test_html_visitor_emits_expected_wrapper(options, expected_open):
+    node = _build_directive(options).run()[0]
+    translator = Mock(body=[])
+    visit_diagram_html(translator, node)
+    depart_diagram_html(translator, node)
+    assert translator.body == [expected_open, "</div>"]
 
 
 @pytest.mark.parametrize(
@@ -88,3 +113,242 @@ def test_diagram_wrapper(arguments, options, content, expected_open, expected_cl
 )
 def test_comma_list_normalizes_values(raw, expected):
     assert _comma_list(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("a,b,c", ["a", "b", "c"]),
+        ("", []),
+        (None, []),
+    ],
+)
+def test_split_returns_list(raw, expected):
+    assert _split(raw) == expected
+
+
+# _page_url ------------------------------------------------------------------
+
+
+def _mock_app(builder_name="dirhtml", html_baseurl="https://example.com"):
+    return SimpleNamespace(
+        config=SimpleNamespace(html_baseurl=html_baseurl),
+        builder=SimpleNamespace(name=builder_name),
+        env=SimpleNamespace(images={}),
+    )
+
+
+@pytest.mark.parametrize(
+    "builder, docname, anchor, expected",
+    [
+        # dirhtml
+        ("dirhtml", "index", "", "https://example.com/"),
+        ("dirhtml", "index", "foo", "https://example.com/#foo"),
+        ("dirhtml", "examples/images", "", "https://example.com/examples/images/"),
+        (
+            "dirhtml",
+            "examples/images",
+            "auth-flow",
+            "https://example.com/examples/images/#auth-flow",
+        ),
+        # docname that ends in /index becomes a directory URL
+        (
+            "dirhtml",
+            "examples/index",
+            "",
+            "https://example.com/examples/",
+        ),
+        # html builder uses .html suffix
+        ("html", "examples/images", "", "https://example.com/examples/images.html"),
+        (
+            "html",
+            "examples/images",
+            "auth-flow",
+            "https://example.com/examples/images.html#auth-flow",
+        ),
+    ],
+)
+def test_page_url_combinations(builder, docname, anchor, expected, monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    app = _mock_app(builder_name=builder)
+    assert _page_url(app, docname, anchor=anchor) == expected
+
+
+def test_page_url_includes_multiversion_slug(monkeypatch):
+    monkeypatch.setenv("SPHINX_MULTIVERSION_OUTPUTDIR", "/build/dirhtml/stable")
+    app = _mock_app(builder_name="dirhtml")
+    assert (
+        _page_url(app, "examples/images", anchor="auth-flow")
+        == "https://example.com/stable/examples/images/#auth-flow"
+    )
+
+
+def test_page_url_without_baseurl(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    app = _mock_app(html_baseurl="")
+    assert _page_url(app, "examples/images") == "examples/images/"
+
+
+# _image_url -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri, expected",
+    [
+        ("https://cdn.example.com/foo.png", "https://cdn.example.com/foo.png"),
+        ("http://cdn.example.com/foo.png", "http://cdn.example.com/foo.png"),
+        (
+            "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+            "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+        ),
+    ],
+)
+def test_image_url_passes_through_absolute_uris(uri, expected, monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    assert _image_url(_mock_app(), uri) == expected
+
+
+def test_image_url_passes_through_already_prefixed(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    assert (
+        _image_url(_mock_app(), "_images/diagram.svg")
+        == "https://example.com/_images/diagram.svg"
+    )
+
+
+def test_image_url_uses_env_images_mapping(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    app = _mock_app()
+    app.env.images = {"images/diagram.svg": ({"index"}, "diagram1.svg")}
+    assert (
+        _image_url(app, "images/diagram.svg")
+        == "https://example.com/_images/diagram1.svg"
+    )
+
+
+def test_image_url_falls_back_to_basename(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    app = _mock_app()
+    app.env.images = {}
+    assert (
+        _image_url(app, "deep/nested/checkmark.png")
+        == "https://example.com/_images/checkmark.png"
+    )
+
+
+def test_image_url_returns_none_for_empty_uri():
+    assert _image_url(_mock_app(), "") is None
+
+
+def test_image_url_without_baseurl_returns_root_relative(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    app = _mock_app(html_baseurl="")
+    assert _image_url(app, "images/foo.png") == "/_images/foo.png"
+
+
+# End-to-end integration: build a tiny Sphinx project and inspect diagrams.json
+# to verify both image and mermaid entries are emitted with absolute URLs.
+
+
+def _write_min_project(root: Path):
+    (root / "conf.py").write_text(
+        dedent(
+            """
+            extensions = ["sphinx_scylladb_theme"]
+            html_theme = "sphinx_scylladb_theme"
+            master_doc = "index"
+            html_baseurl = "https://example.com"
+            project = "diagrams-test"
+            html_theme_options = {"site_description": "test"}
+            html_context = {"html_baseurl": html_baseurl}
+            """
+        )
+    )
+    (root / "img.png").write_bytes(b"")
+    (root / "index.rst").write_text(
+        dedent(
+            """
+            Diagram E2E
+            ===========
+
+            .. diagram::
+               :id: img-diagram
+               :tags: networking, security
+               :categories: security
+               :deployment: core
+               :last-reviewed: 2026-06-01
+
+               .. figure:: img.png
+                  :alt: An image
+
+                  An image.
+
+            .. diagram::
+               :id: mermaid-diagram
+               :tags: arch
+
+               .. mermaid::
+
+                  graph TD
+                  A --> B
+
+            .. diagram::
+
+               .. mermaid::
+
+                  graph TD
+                  X --> Y
+            """
+        )
+    )
+
+
+def test_diagrams_json_includes_image_and_mermaid_entries(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    out = tmp_path / "out"
+    _write_min_project(src)
+
+    result = subprocess.run(
+        ["uv", "run", "sphinx-build", "-q", "-b", "dirhtml", str(src), str(out)],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[2],
+    )
+    assert result.returncode == 0, result.stderr
+
+    data = json.loads((out / "diagrams.json").read_text())
+    assert "diagrams" in data
+    entries_by_id = {e["id"]: e for e in data["diagrams"] if e["id"] is not None}
+    assert set(entries_by_id) == {"img-diagram", "mermaid-diagram"}
+
+    # Diagram without :id: still appears (no anchor in page_url, null id).
+    anonymous = [e for e in data["diagrams"] if e["id"] is None]
+    assert len(anonymous) == 1
+    assert anonymous[0]["type"] == "mermaid"
+    assert "X --> Y" in anonymous[0]["content"]
+    assert anonymous[0]["page_url"] == "https://example.com/"
+    assert anonymous[0]["last_reviewed"] is None
+    assert anonymous[0]["deployment"] is None
+
+    entries = entries_by_id
+
+    img = entries["img-diagram"]
+    assert img["type"] == "image"
+    assert img["content"].startswith("https://example.com/_images/")
+    assert img["content"].endswith(".png")
+    assert img["page"] == "index"
+    assert img["page_url"] == "https://example.com/#img-diagram"
+    assert img["tags"] == ["networking", "security"]
+    assert img["categories"] == ["security"]
+    assert img["deployment"] == "core"
+    assert img["last_reviewed"] == "2026-06-01"
+
+    mmd = entries["mermaid-diagram"]
+    assert mmd["type"] == "mermaid"
+    assert "graph TD" in mmd["content"]
+    assert "A --> B" in mmd["content"]
+    assert mmd["page_url"] == "https://example.com/#mermaid-diagram"
+    assert mmd["tags"] == ["arch"]
+    assert mmd["categories"] == []
+    assert mmd["deployment"] is None

--- a/tests/extensions/test_extensions_utils.py
+++ b/tests/extensions/test_extensions_utils.py
@@ -1,7 +1,14 @@
+from types import SimpleNamespace
+
+import pytest
+
 from sphinx_scylladb_theme.extensions.utils import (
+    base_url,
     build_redirect_body,
     generate_template,
     is_url,
+    latest_version_slug,
+    version_slug,
 )
 
 
@@ -44,3 +51,69 @@ def test_is_url_external():
 def test_is_url_relative_path():
     path = "/relative_path"
     assert not is_url(path)
+
+
+# version_slug ---------------------------------------------------------------
+
+
+def test_version_slug_empty_outside_multiversion(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    assert version_slug() == ""
+
+
+@pytest.mark.parametrize(
+    "outdir, expected",
+    [
+        ("/build/dirhtml/stable", "stable"),
+        ("/build/dirhtml/branch-1.9/", "branch-1.9"),
+        ("stable", "stable"),
+    ],
+)
+def test_version_slug_returns_basename_of_outputdir(monkeypatch, outdir, expected):
+    monkeypatch.setenv("SPHINX_MULTIVERSION_OUTPUTDIR", outdir)
+    assert version_slug() == expected
+
+
+# base_url -------------------------------------------------------------------
+
+
+def test_base_url_empty_when_html_baseurl_unset(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    config = SimpleNamespace(html_baseurl="")
+    assert base_url(config) == ""
+
+
+def test_base_url_strips_trailing_slash(monkeypatch):
+    monkeypatch.delenv("SPHINX_MULTIVERSION_OUTPUTDIR", raising=False)
+    config = SimpleNamespace(html_baseurl="https://example.com/")
+    assert base_url(config) == "https://example.com"
+
+
+def test_base_url_appends_multiversion_slug(monkeypatch):
+    monkeypatch.setenv("SPHINX_MULTIVERSION_OUTPUTDIR", "/build/dirhtml/stable")
+    config = SimpleNamespace(html_baseurl="https://example.com")
+    assert base_url(config) == "https://example.com/stable"
+
+
+# latest_version_slug --------------------------------------------------------
+
+
+def test_latest_version_slug_prefers_rename():
+    config = SimpleNamespace(
+        smv_rename_latest_version="stable",
+        smv_latest_version="branch-1.9",
+    )
+    assert latest_version_slug(config) == "stable"
+
+
+def test_latest_version_slug_falls_back_to_latest():
+    config = SimpleNamespace(
+        smv_rename_latest_version=None,
+        smv_latest_version="branch-1.9",
+    )
+    assert latest_version_slug(config) == "branch-1.9"
+
+
+def test_latest_version_slug_empty_when_neither_configured():
+    config = SimpleNamespace(smv_rename_latest_version=None, smv_latest_version="")
+    assert latest_version_slug(config) == ""


### PR DESCRIPTION
## Motivation

Extends the `diagram` directive to also emit a single `diagrams.json` per build, listing every wrapped diagram with its metadata plus either an absolute image URL or the raw mermaid source. 

External tools can query the stable URL like `https://sphinx-theme.scylladb.com/stable/diagrams.json` to filter and extract diagrams without scraping HTML.

## JSON shape

```json
{
  "diagrams": [
    {
      "id": "request-flow",
      "page": "examples/diagrams",
      "page_url": "https://sphinx-theme.scylladb.com/stable/examples/diagrams.html#request-flow",
      "tags": ["networking", "ingress"],
      "categories": ["architecture"],
      "deployment": "core",
      "last_reviewed": "2026-06-01",
      "type": "mermaid",
      "content": "graph TD\nClient --> Gateway\nGateway -- Auth --> Service\nService --> Database"
    },
    {
      "id": "auth-flow",
      "page": "examples/images",
      "page_url": "https://sphinx-theme.scylladb.com/stable/examples/images.html#auth-flow",
      "tags": ["networking", "security"],
      "categories": ["security"],
      "deployment": "core",
      "last_reviewed": "2026-06-01",
      "type": "image",
      "content": "https://sphinx-theme.scylladb.com/stable/_images/diagram.svg"
    }
  ]
}
```

## How to test

1. Build the docs
2. Open http://127.0.0.1:5500/diagrams.json