### PR TITLE
feat: warn when external-link syntax is used for internal docs

### DIFF
--- a/sphinx_scylladb_theme/extensions/validations.py
+++ b/sphinx_scylladb_theme/extensions/validations.py
@@ -1,3 +1,6 @@
+from urllib.parse import urlparse
+
+from docutils import nodes
 from sphinx.util import logging
 
 logger = logging.getLogger(__name__)
@@ -21,8 +24,34 @@ def warn_on_underscores(app, docname, source):
     return False
 
 
+def warn_on_internal_docs_as_external_links(app, doctree, docname):
+    theme_options = app.config.html_theme_options
+    skip_warnings = theme_options.get("skip_warnings", [])
+    if "internal_docs_as_external_link" in skip_warnings:
+        return False
+
+    reported = False
+    for ref in doctree.traverse(nodes.reference):
+        if ref.get("internal"):
+            continue
+        refuri = ref.get("refuri", "")
+        if not refuri or refuri.startswith("#") or urlparse(refuri).scheme:
+            continue
+        line = ref.line or (ref.parent.line if ref.parent is not None else 0) or 0
+        logger.warning(
+            'External link "%s" has no URL scheme. '
+            "Use :doc:`%s` for internal docs or prefix with http/https/mailto/... .",
+            refuri,
+            refuri,
+            location=(docname, line),
+        )
+        reported = True
+    return reported
+
+
 def setup(app):
     app.connect("source-read", warn_on_underscores)
+    app.connect("doctree-resolved", warn_on_internal_docs_as_external_links)
     return {
         "version": "0.1",
         "parallel_read_safe": True,

--- a/tests/extensions/test_validations.py
+++ b/tests/extensions/test_validations.py
@@ -1,6 +1,15 @@
+import subprocess
+from pathlib import Path
+from textwrap import dedent
 from unittest.mock import MagicMock
 
-from sphinx_scylladb_theme.extensions.validations import warn_on_underscores
+import pytest
+from docutils import nodes
+
+from sphinx_scylladb_theme.extensions.validations import (
+    warn_on_internal_docs_as_external_links,
+    warn_on_underscores,
+)
 
 
 def test_warn_on_underscores():
@@ -17,3 +26,154 @@ def test_skip_warn_on_underscores():
     app_mock.config.html_theme_options = html_theme_options
 
     assert warn_on_underscores(app_mock, "file_name.rst", None) is False
+
+
+# warn_on_internal_docs_as_external_links -----------------------------------
+
+
+def _make_app(skip_warnings=None):
+    app = MagicMock()
+    app.config.html_theme_options = {"skip_warnings": skip_warnings or []}
+    return app
+
+
+def _make_doctree(references):
+    refs = [nodes.reference(**kw) for kw in references]
+    tree = MagicMock()
+    tree.traverse = lambda cls: [r for r in refs if isinstance(r, cls)]
+    return tree
+
+
+@pytest.mark.parametrize(
+    "refuri",
+    [
+        "disable-housekeeping",
+        "bar.html",
+        "../other/",
+        "www.example.com",
+        "/stable/thing/",
+    ],
+)
+def test_warns_when_external_syntax_lacks_url_scheme(refuri, caplog):
+    app = _make_app()
+    doctree = _make_doctree([{"refuri": refuri, "internal": False}])
+    with caplog.at_level("WARNING"):
+        assert (
+            warn_on_internal_docs_as_external_links(app, doctree, "current-doc") is True
+        )
+    joined = "\n".join(caplog.messages)
+    assert refuri in joined
+    assert ":doc:" in joined
+
+
+@pytest.mark.parametrize(
+    "refuri",
+    [
+        "https://example.com",
+        "http://example.com/path",
+        "ftp://example.com",
+        "mailto:foo@example.com",
+        "javascript:void(0)",
+        "file:///path",
+        "#some-section",
+    ],
+)
+def test_silent_when_refuri_has_scheme_or_is_anchor(refuri, caplog):
+    app = _make_app()
+    doctree = _make_doctree([{"refuri": refuri, "internal": False}])
+    with caplog.at_level("WARNING"):
+        assert (
+            warn_on_internal_docs_as_external_links(app, doctree, "current-doc")
+            is False
+        )
+    assert caplog.messages == []
+
+
+def test_silent_for_resolved_doc_reference(caplog):
+    app = _make_app()
+    doctree = _make_doctree([{"refuri": "disable-housekeeping", "internal": True}])
+    with caplog.at_level("WARNING"):
+        assert (
+            warn_on_internal_docs_as_external_links(app, doctree, "current-doc")
+            is False
+        )
+    assert caplog.messages == []
+
+
+def test_silent_when_skip_flag_set(caplog):
+    app = _make_app(skip_warnings=["internal_docs_as_external_link"])
+    doctree = _make_doctree([{"refuri": "disable-housekeeping", "internal": False}])
+    with caplog.at_level("WARNING"):
+        assert (
+            warn_on_internal_docs_as_external_links(app, doctree, "current-doc")
+            is False
+        )
+    assert caplog.messages == []
+
+
+def test_silent_for_empty_refuri(caplog):
+    app = _make_app()
+    doctree = _make_doctree([{"refuri": "", "internal": False}])
+    with caplog.at_level("WARNING"):
+        assert (
+            warn_on_internal_docs_as_external_links(app, doctree, "current-doc")
+            is False
+        )
+    assert caplog.messages == []
+
+
+# End-to-end: parse the two real RST syntaxes from issue #532 and verify only
+# the external-syntax form triggers the warning.
+
+
+def _write_min_project(root: Path):
+    (root / "conf.py").write_text(
+        dedent(
+            """
+            extensions = ["sphinx_scylladb_theme"]
+            html_theme = "sphinx_scylladb_theme"
+            master_doc = "index"
+            html_baseurl = "https://example.com"
+            project = "validations-test"
+            html_theme_options = {"site_description": "test"}
+            html_context = {"html_baseurl": html_baseurl}
+            """
+        )
+    )
+    (root / "disable-housekeeping.rst").write_text(
+        "Disable housekeeping\n====================\n\nBody.\n"
+    )
+    (root / "index.rst").write_text(
+        dedent(
+            """
+            Validations E2E
+            ===============
+
+            * :doc:`Scylla Housekeeping and how to disable it <disable-housekeeping>`
+            * `Scylla Housekeeping and how to disable it <disable-housekeeping>`_
+            """
+        )
+    )
+
+
+def test_end_to_end_only_external_syntax_triggers_warning(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    out = tmp_path / "out"
+    _write_min_project(src)
+
+    result = subprocess.run(
+        ["uv", "run", "sphinx-build", "-q", "-b", "dirhtml", str(src), str(out)],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[2],
+    )
+    combined = result.stdout + result.stderr
+
+    warnings = [
+        line
+        for line in combined.splitlines()
+        if "has no URL scheme" in line and "disable-housekeeping" in line
+    ]
+    assert len(warnings) == 1, f"expected 1 warning, got {len(warnings)}:\n{combined}"
+    assert ":doc:" in warnings[0]


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/532

## How to test

1. Edit `docs/source/configuration/ai-chatbot.rst` and paste at the bottom:

   ```rst
   Should warn — no URL scheme:

   * `Bare slug <dependabot>`_
   * `With .html suffix <bar.html>`_
   * `Relative path <../other/>`_
   * `Missing scheme <www.example.com>`_
   * `Hardcoded version </stable/thing/>`_

   .. _test-ref:

   Should NOT warn:

   * :ref:`Section reference <test-ref>`
   * :doc:`Bare slug <dependabot>`
   * `External URL <https://example.com>`_
   * `Email <mailto:x@y.com>`_
   * `Anchor <#section>`_
   ```

2. Run `make preview`.
3. Expect one warning per line on the first group. The second group must produce no warnings.