### PR TITLE
feat: noindex preview builds

### DIFF
--- a/sphinx_scylladb_theme/layout.html
+++ b/sphinx_scylladb_theme/layout.html
@@ -56,6 +56,17 @@
         <link rel="apple-touch-icon" href="{{ pathto('_static/img/favicon-228x228.png', 1) }}" />
         <meta name="msapplication-TileImage" href="{{ pathto('_static/img/favicon-228x228.png', 1) }}" />
 
+        <script>
+            (function () {
+                if (window.location.hostname === 'previews.docs.scylladb.com') {
+                    var meta = document.createElement('meta');
+                    meta.name = 'robots';
+                    meta.content = 'noindex, nofollow';
+                    document.head.appendChild(meta);
+                }
+            })();
+        </script>
+
         {% if pagename == "index" %}
             {% set canonical_page = "" %}
         {% elif pagename.endswith("/index") %}


### PR DESCRIPTION
# Motivation

Preview builds under `previews.docs.scylladb.com` were being indexed by Google.
Injects `<meta name="robots" content="noindex, nofollow">` in `<head>` only when the hostname matches.

## How to test

No way to reproduce the preview domain from this repo. 

Still, we can test the opposite case.
Run `make preview` and confirm the `robots` meta does **not** appear in the built HTML (only the script).