### PR TITLE
feat: add scylla-check-redirects validator

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -33,5 +33,8 @@ jobs:
       - name: Set up env
         run: make -C docs setupenv
 
+      - name: Check redirects
+        run: make -C docs check-redirects
+
       - name: Build docs
         run: make -C docs test

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -75,6 +75,10 @@ redirects: setup
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+.PHONY: check-redirects
+check-redirects: setup
+	$(UV) run scylla-check-redirects --yaml _utils/redirects.yaml --conf $(SOURCEDIR)
+
 # Preview commands
 .PHONY: preview
 preview: setup

--- a/docs/source/upgrade/1-9-to-1-10.rst
+++ b/docs/source/upgrade/1-9-to-1-10.rst
@@ -1,0 +1,43 @@
+Upgrading from 1.9 to 1.10
+==========================
+
+This guide explains how to upgrade the version of the ScyllaDB Sphinx Theme
+from 1.9 to 1.10.
+
+How to check your current theme version
+---------------------------------------
+
+The theme version is displayed in the footer of the project's documentation site.
+
+.. image:: version.png
+
+If your project theme's version is **>=1.9**, follow this guide to get the
+latest version.
+
+What's new in 1.10
+------------------
+
+See the :doc:`CHANGELOG <CHANGELOG>` for the full list of changes in this
+release.
+
+Upgrade to version 1.10
+-----------------------
+
+Enable the redirect validator on pull requests
+..............................................
+
+1. Add a ``check-redirects`` **target to** ``docs/Makefile``.
+    It checks every ``/stable/`` redirect target is reachable on the live site:
+
+.. code-block:: makefile
+
+    .PHONY: check-redirects
+    check-redirects: setup
+        $(UV) run scylla-check-redirects --yaml _utils/redirects.yaml --conf $(SOURCEDIR)
+
+2. Add a step to** ``.github/workflows/docs-pr.yaml`` before the docs build so bad redirects fail fast:
+
+.. code-block:: yaml
+
+    - name: Check redirects
+      run: make -C docs check-redirects

--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -8,6 +8,7 @@ Upgrade guides
    :maxdepth: 2
    :hidden:
 
+   1-9-to-1-10
    1-8-to-1-9
    1-7-to-1-8
    1-6-to-1-7
@@ -22,6 +23,7 @@ Upgrade guides
 
 .. panel-box::
 
+  * :doc:`Upgrading from 1.9 to 1.10 <1-9-to-1-10>`
   * :doc:`Upgrading from 1.8 to 1.9 <1-8-to-1-9>`
   * :doc:`Upgrading from 1.7 to 1.8 <1-7-to-1-8>`
   * :doc:`Upgrading from 1.6 to 1.7 <1-6-to-1-7>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sphinx-scylladb-theme"
-version = "1.9.3"
+version = "1.10.0"
 description = "A Sphinx Theme for ScyllaDB documentation projects"
 authors = [{name = "David García", email = "david@techdocs.studio"}]
 readme = "PYPI.rst"
@@ -42,6 +42,9 @@ dev = [
     "redirects_cli>=0.1.3,<0.2",
     "breathe>=4.36.0,<5",
 ]
+
+[project.scripts]
+scylla-check-redirects = "sphinx_scylladb_theme.cli.redirects_check:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/sphinx_scylladb_theme/cli/redirects_check.py
+++ b/sphinx_scylladb_theme/cli/redirects_check.py
@@ -1,0 +1,162 @@
+"""
+Catches redirects merged to master whose target has not yet been
+released to ``/stable/``, which would otherwise leave real users on
+the current stable version hitting a 404.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+EXTERNAL_URL_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
+
+ADVICE = """
+These redirects would send real users to a 404 after deploy.
+
+This usually means the target page was added on master but the version
+that its URL prefix references has not been re-released yet.
+
+Recommended fix:
+  1. Remove the affected entries from redirects.yaml in this PR.
+  2. Open a follow-up PR that only adds those entries.
+  3. Merge the follow-up PR AFTER the version containing the target
+     page is released and deployed.
+""".strip()
+
+_HTTP_TIMEOUT = 10
+
+
+def load_redirects(yaml_path: Path) -> dict[str, str]:
+    with open(yaml_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def _default_http_head(url: str) -> int | None:
+    """Returns the HTTP status code, or None on network error."""
+    req = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except (urllib.error.URLError, TimeoutError, ConnectionError):
+        return None
+
+
+def target_is_live(base_url: str, target: str, http_head=None) -> bool | None:
+    if EXTERNAL_URL_RE.match(target):
+        return True
+
+    head = http_head or _default_http_head
+    url = base_url.rstrip("/") + target
+    status = head(url)
+    if status is None:
+        return None
+    return 200 <= status < 300
+
+
+def check_live(
+    yaml_path: Path,
+    base_url: str,
+    prefix: str = "stable",
+    http_head=None,
+) -> list[tuple[str, str]]:
+    entries = load_redirects(yaml_path)
+    marker = f"/{prefix.strip('/')}/"
+    missing = []
+    for old, new in entries.items():
+        target = str(new)
+        if not target.startswith(marker):
+            continue
+        result = target_is_live(base_url, target, http_head=http_head)
+        if result is False:
+            missing.append((old, new))
+    return missing
+
+
+def read_base_url(confdir: Path) -> str:
+    from sphinx.config import eval_config_file
+    from sphinx.util.tags import Tags
+
+    # eval_config_file chdirs into filename.parent then reads filename,
+    # so filename must be absolute or the read fails after the chdir.
+    namespace = eval_config_file((confdir / "conf.py").resolve(), Tags())
+    url = str(namespace.get("html_baseurl") or "").strip()
+    if not url:
+        raise ValueError(
+            f"html_baseurl is not set in {confdir}/conf.py; "
+            f"cannot determine the live site to check against"
+        )
+    return url.rstrip("/")
+
+
+def _report_missing(missing: list[tuple[str, str]], where: str) -> int:
+    print(
+        f"error: {len(missing)} redirect target(s) missing from {where}:",
+        file=sys.stderr,
+    )
+    for old, new in missing:
+        print(f"  {new}  (from {old})", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(ADVICE, file=sys.stderr)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--yaml", required=True, type=Path, help="Path to redirects.yaml"
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--conf",
+        type=Path,
+        help=(
+            "Read html_baseurl from the Sphinx conf.py in this directory "
+            "and check every /<stable-prefix>/ target is reachable on it."
+        ),
+    )
+    mode.add_argument(
+        "--stable-base-url",
+        help="Explicit live-site URL, mainly for tests and edge cases.",
+    )
+    parser.add_argument(
+        "--stable-prefix",
+        default="stable",
+        help='URL prefix that maps to the rolling latest release (default: "stable").',
+    )
+    args = parser.parse_args(argv)
+
+    if not args.yaml.is_file():
+        print(f"error: redirects file not found: {args.yaml}", file=sys.stderr)
+        return 2
+
+    if args.conf is not None:
+        if not (args.conf / "conf.py").is_file():
+            print(f"error: conf.py not found in {args.conf}", file=sys.stderr)
+            return 2
+        try:
+            base_url = read_base_url(args.conf)
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+    else:
+        base_url = args.stable_base_url
+
+    missing = check_live(args.yaml, base_url, args.stable_prefix)
+    if missing:
+        return _report_missing(missing, base_url)
+    print(f"ok: all /{args.stable_prefix}/ redirect target(s) return 2xx on {base_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_redirects_check.py
+++ b/tests/test_redirects_check.py
@@ -1,0 +1,162 @@
+import pytest
+import yaml
+
+from sphinx_scylladb_theme.cli.redirects_check import (
+    check_live,
+    main,
+    read_base_url,
+    target_is_live,
+)
+
+# -- read_base_url ----------------------------------------------------------
+
+
+def test_read_base_url_from_conf(tmp_path):
+    (tmp_path / "conf.py").write_text('html_baseurl = "https://docs.example.com/"\n')
+    assert read_base_url(tmp_path) == "https://docs.example.com"
+
+
+def test_read_base_url_missing_raises(tmp_path):
+    (tmp_path / "conf.py").write_text("")
+    with pytest.raises(ValueError, match="html_baseurl is not set"):
+        read_base_url(tmp_path)
+
+
+# -- CLI plumbing -----------------------------------------------------------
+
+
+def test_main_missing_yaml(tmp_path, capsys):
+    rc = main(
+        [
+            "--yaml",
+            str(tmp_path / "missing.yaml"),
+            "--stable-base-url",
+            "https://x",
+        ]
+    )
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_main_conf_missing_conf_py(tmp_path, capsys):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text("")
+    rc = main(["--yaml", str(yaml_path), "--conf", str(tmp_path)])
+    assert rc == 2
+    assert "conf.py not found" in capsys.readouterr().err
+
+
+def test_main_conf_and_stable_are_mutually_exclusive(tmp_path):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text("")
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--yaml",
+                str(yaml_path),
+                "--conf",
+                str(tmp_path),
+                "--stable-base-url",
+                "https://example.com",
+            ]
+        )
+
+
+def test_main_requires_a_mode(tmp_path):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text("")
+    with pytest.raises(SystemExit):
+        main(["--yaml", str(yaml_path)])
+
+
+# -- target_is_live / check_live -------------------------------------------
+
+
+class FakeHTTP:
+    """Records requested URLs and returns a scripted status per URL."""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, url):
+        self.calls.append(url)
+        return self.responses.get(url)
+
+
+def test_target_is_live_2xx_true():
+    http = FakeHTTP({"https://x/stable/foo.html": 200})
+    assert target_is_live("https://x", "/stable/foo.html", http_head=http) is True
+
+
+def test_target_is_live_404_false():
+    http = FakeHTTP({"https://x/stable/gone.html": 404})
+    assert target_is_live("https://x", "/stable/gone.html", http_head=http) is False
+
+
+def test_target_is_live_network_error_none():
+    http = FakeHTTP({"https://x/stable/foo.html": None})
+    assert target_is_live("https://x", "/stable/foo.html", http_head=http) is None
+
+
+def test_target_is_live_external_url_skipped():
+    http = FakeHTTP({})
+    assert target_is_live("https://x", "https://other/", http_head=http) is True
+    assert http.calls == []
+
+
+def test_target_is_live_strips_trailing_slash_on_base():
+    http = FakeHTTP({"https://x/stable/foo.html": 200})
+    target_is_live("https://x/", "/stable/foo.html", http_head=http)
+    assert http.calls == ["https://x/stable/foo.html"]
+
+
+def test_check_live_only_checks_stable_prefix(tmp_path):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "/stable/a.html": "/stable/live.html",  # /stable/, 200 -> ok
+                "/stable/b.html": "/stable/dead.html",  # /stable/, 404 -> fail
+                "/1.7/c.html": "/1.7/anything.html",  # not /stable/ -> skip
+                "/stable/d.html": "https://external/",  # external -> skip
+            }
+        )
+    )
+    http = FakeHTTP(
+        {
+            "https://x/stable/live.html": 200,
+            "https://x/stable/dead.html": 404,
+        }
+    )
+    missing = check_live(yaml_path, "https://x", http_head=http)
+    assert missing == [("/stable/b.html", "/stable/dead.html")]
+    assert "https://x/1.7/anything.html" not in http.calls
+
+
+def test_check_live_network_error_is_skipped(tmp_path):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text(yaml.safe_dump({"/stable/a.html": "/stable/x.html"}))
+    http = FakeHTTP({"https://x/stable/x.html": None})  # network error
+    assert check_live(yaml_path, "https://x", http_head=http) == []
+
+
+def test_check_live_custom_prefix(tmp_path):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "/latest/a.html": "/latest/dead.html",
+                "/stable/b.html": "/stable/dead.html",  # ignored under prefix=latest
+            }
+        )
+    )
+    http = FakeHTTP({"https://x/latest/dead.html": 404})
+    missing = check_live(yaml_path, "https://x", prefix="latest", http_head=http)
+    assert missing == [("/latest/a.html", "/latest/dead.html")]
+
+
+def test_check_live_empty_yaml(tmp_path):
+    yaml_path = tmp_path / "redirects.yaml"
+    yaml_path.write_text("")
+    assert check_live(yaml_path, "https://x", http_head=FakeHTTP({})) == []

--- a/uv.lock
+++ b/uv.lock
@@ -825,7 +825,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-scylladb-theme"
-version = "1.9.3"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Problem 

Redirects are defined on the master branch, so they take effect before the next documentation version is released.
For example, if `/stable/foo.html` redirects to `/stable/bar.html`, but bar.html only exists on master, users following the redirect get a 404 until the next release updates `/stable`.

## Analysis 

Defining redirects per version is not practical: 

* **Does not work for tag-based projects:** Some projects, such as Python, build documentation from immutable git tags. Redirect configuration cannot be added to an already released tag.
* **High backport cost:** Existing redirects would need to be copied to every supported version branch across every project, creating significant maintenance work and risk of drift.
* **Central configuration is still useful:** Keeping redirects in a single file on master allows redirects for any version to be managed in one place and aligns with the planned move to centrally managed Cloudflare glob redirects. 

## Solution

Warn when a new redirect affects `/stable` but its target page does not yet exist in the current stable version.

In these cases, the redirect should be added in a follow-up PR and merged after the new version is released. The warning provides guidance for creating and merging that follow-up PR.