### PR TITLE
feat: add page anchors extension

### DIFF
--- a/docs/source/examples/links.rst
+++ b/docs/source/examples/links.rst
@@ -36,7 +36,7 @@ There are a few links you can use with different purposes.
      - Renders the parameter name as a hyperlink.
      - This is an internal cross-reference to a parameter on the `Configuration Parameters <https://opensource.docs.scylladb.com/stable/reference/configuration-parameters.html>`_ page.
        It does NOT require a bookmark, as parameter names on that are page implicit bookmarks. Content opens in the same tab.
-       This option only applies to the ``scylladb/sylladb`` and ``scylladb/scylla-enterprise`` projects. 
+       This option only applies to the ``scylladb/sylladb`` and ``scylladb/scylla-enterprise`` projects.
    * - Internal Cross-reference to Parameter Gropus
      - .. code-block:: rst
 
@@ -44,7 +44,7 @@ There are a few links you can use with different purposes.
      - Renders the name of the parameter group as a hyperlink.
      - This is an internal cross-reference to a parameter group on the `Configuration Parameters <https://opensource.docs.scylladb.com/stable/reference/configuration-parameters.html>`_ page.
        It does NOT require a bookmark, as group names on that are page implicit bookmarks. Content opens in the same tab.
-       This option only applies to the ``scylladb/sylladb`` and ``scylladb/scylla-enterprise`` projects. 
+       This option only applies to the ``scylladb/sylladb`` and ``scylladb/scylla-enterprise`` projects.
    * - Internal Doc Reference
      - .. code-block:: rst
 
@@ -58,3 +58,14 @@ There are a few links you can use with different purposes.
 
      - :download:`download <index.rst>`
      - This opens a download window. It is used to help users download software or files.
+   * - Page Anchor Link
+     - .. code-block:: rst
+
+          :page-anchor:`System requirements </examples/headings#system-requirements>`
+
+     - :page-anchor:`System requirements </examples/headings#system-requirements>`
+     - Links to an arbitrary anchor of any page in the project, without validating the anchor.
+       Use it for anchors that Sphinx cannot see at build time because JavaScript generates them,
+       such as endpoint deep links on API reference pages rendered with Redoc or Swagger UI.
+       Whenever possible, prefer built-in Sphinx roles such as ``:ref:`` or ``:doc:``,
+       which validate the target at build time.

--- a/sphinx_scylladb_theme/__init__.py
+++ b/sphinx_scylladb_theme/__init__.py
@@ -17,6 +17,7 @@ from sphinx_scylladb_theme.extensions import (
     labels,
     multiversion,
     navigation,
+    page_anchor,
     panel_box,
     topic_box,
     validations,
@@ -153,6 +154,7 @@ def setup(app):
     include_tooltip.setup(app)
     labels.setup(app)
     multiversion.setup(app)
+    page_anchor.setup(app)
     panel_box.setup(app)
     topic_box.setup(app)
     validations.setup(app)

--- a/sphinx_scylladb_theme/extensions/page_anchor.py
+++ b/sphinx_scylladb_theme/extensions/page_anchor.py
@@ -1,0 +1,96 @@
+"""
+Sphinx role to link to an arbitrary anchor of any page in the project.
+
+Sphinx cross-reference roles (``:ref:``, ``:doc:``) can only target anchors
+that exist in the doctree at build time. Anchors generated client-side by
+JavaScript widgets (Redoc, Swagger UI, etc.) are invisible to Sphinx, so
+pages like an OpenAPI reference cannot be deep-linked with standard roles.
+
+This role resolves the page URL through the builder (so relative paths stay
+correct at any nesting depth and in multiversion builds) and appends the
+anchor verbatim, without validating it:
+
+.. code-block:: rst
+
+   :page-anchor:`Install Vector Search </api#tag/VectorSearch/operation/installVectorSearch>`
+   :page-anchor:`/api#tag/VectorSearch/operation/installVectorSearch`
+"""
+
+from posixpath import dirname, join, normpath
+
+from docutils import nodes
+from sphinx.util import logging
+from sphinx.util.docutils import SphinxRole
+from sphinx.util.nodes import split_explicit_title
+
+LOGGER = logging.getLogger(__name__)
+
+
+class page_anchor_pending(nodes.Element):
+    """Placeholder node resolved once the builder can compute URLs."""
+
+
+class PageAnchorRole(SphinxRole):
+    def run(self):
+        has_explicit_title, title, target = split_explicit_title(self.text)
+
+        if "#" in target:
+            docpath, anchor = target.split("#", 1)
+        else:
+            docpath, anchor = target, ""
+
+        if docpath.startswith("/"):
+            docname = docpath.lstrip("/")
+        else:
+            docname = normpath(join(dirname(self.env.docname), docpath))
+
+        if not has_explicit_title:
+            title = target
+
+        node = page_anchor_pending(
+            self.rawtext,
+            docname=docname,
+            anchor=anchor,
+            title=title,
+        )
+        self.set_source_info(node)
+        return [node], []
+
+
+def resolve_page_anchors(app, doctree, fromdocname):
+    additional_pages = getattr(app.config, "html_additional_pages", None) or {}
+
+    for node in list(doctree.findall(page_anchor_pending)):
+        docname = node["docname"]
+        anchor = node["anchor"]
+        title = node["title"]
+
+        if docname not in app.env.found_docs and docname not in additional_pages:
+            LOGGER.warning(
+                "page-anchor: unknown document %r (not a source document "
+                "or an html_additional_pages entry)",
+                docname,
+                location=node,
+            )
+
+        try:
+            uri = app.builder.get_relative_uri(fromdocname, docname)
+        except Exception:
+            uri = docname
+        if anchor:
+            uri += "#" + anchor
+
+        reference = nodes.reference("", "", internal=True, refuri=uri)
+        reference += nodes.inline(title, title, classes=["page-anchor"])
+        node.replace_self(reference)
+
+
+def setup(app):
+    app.add_role("page-anchor", PageAnchorRole())
+    app.connect("doctree-resolved", resolve_page_anchors)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tests/extensions/test_page_anchor.py
+++ b/tests/extensions/test_page_anchor.py
@@ -1,0 +1,154 @@
+from unittest.mock import Mock
+
+import pytest
+from docutils import nodes
+
+from sphinx_scylladb_theme.extensions.page_anchor import (
+    PageAnchorRole,
+    page_anchor_pending,
+    resolve_page_anchors,
+)
+
+role_data = [
+    # input_text, current_docname, expected_docname, expected_anchor, expected_title
+    [
+        "Link text </api#tag/Tag/operation/opId>",
+        "examples/links",
+        "api",
+        "tag/Tag/operation/opId",
+        "Link text",
+    ],
+    [
+        "/api#tag/Tag/operation/opId",
+        "examples/links",
+        "api",
+        "tag/Tag/operation/opId",
+        "/api#tag/Tag/operation/opId",
+    ],
+    # Relative path resolves against the current document, like :doc:
+    [
+        "Sibling <sibling#section>",
+        "examples/links",
+        "examples/sibling",
+        "section",
+        "Sibling",
+    ],
+    [
+        "Parent <../index#section>",
+        "examples/links",
+        "index",
+        "section",
+        "Parent",
+    ],
+    # No anchor at all
+    [
+        "Plain </api>",
+        "examples/links",
+        "api",
+        "",
+        "Plain",
+    ],
+]
+
+
+def run_role(input_text, current_docname):
+    role = PageAnchorRole()
+    inliner = Mock()
+    inliner.document.settings.env.docname = current_docname
+    inliner.reporter.get_source_and_line = Mock(return_value=("links.rst", 1))
+    result, messages = role("page-anchor", input_text, input_text, 1, inliner)
+    return result, messages
+
+
+@pytest.mark.parametrize(
+    "input_text, current_docname, expected_docname, expected_anchor, expected_title",
+    role_data,
+)
+def test_page_anchor_role(
+    input_text, current_docname, expected_docname, expected_anchor, expected_title
+):
+    result, messages = run_role(input_text, current_docname)
+
+    assert messages == []
+    assert len(result) == 1
+    node = result[0]
+    assert isinstance(node, page_anchor_pending)
+    assert node["docname"] == expected_docname
+    assert node["anchor"] == expected_anchor
+    assert node["title"] == expected_title
+
+
+def make_app(found_docs, additional_pages=None, relative_uri="../api.html"):
+    app = Mock()
+    app.config.html_additional_pages = additional_pages or {}
+    app.env.found_docs = found_docs
+    app.builder.get_relative_uri = Mock(return_value=relative_uri)
+    return app
+
+
+def make_doctree(pending):
+    paragraph = nodes.paragraph()
+    paragraph += pending
+    return paragraph
+
+
+def test_resolve_page_anchors_builds_relative_uri():
+    pending = page_anchor_pending(
+        "", docname="api", anchor="tag/Tag/operation/opId", title="Link text"
+    )
+    doctree = make_doctree(pending)
+    app = make_app(found_docs={"api"}, relative_uri="../api.html")
+
+    resolve_page_anchors(app, doctree, "examples/links")
+
+    # The URI must come from the builder relative to the current page, so
+    # links stay inside the version subdirectory in multiversion builds.
+    app.builder.get_relative_uri.assert_called_once_with("examples/links", "api")
+    reference = doctree.children[0]
+    assert isinstance(reference, nodes.reference)
+    assert reference["refuri"] == "../api.html#tag/Tag/operation/opId"
+    assert reference["internal"] is True
+    assert reference.astext() == "Link text"
+
+
+def test_resolve_page_anchors_without_anchor():
+    pending = page_anchor_pending("", docname="api", anchor="", title="Plain")
+    doctree = make_doctree(pending)
+    app = make_app(found_docs={"api"}, relative_uri="api.html")
+
+    resolve_page_anchors(app, doctree, "index")
+
+    reference = doctree.children[0]
+    assert reference["refuri"] == "api.html"
+
+
+def test_resolve_page_anchors_accepts_additional_pages():
+    pending = page_anchor_pending("", docname="api", anchor="x", title="API")
+    doctree = make_doctree(pending)
+    app = make_app(
+        found_docs=set(),
+        additional_pages={"api": "redoc.html"},
+        relative_uri="api.html",
+    )
+
+    resolve_page_anchors(app, doctree, "index")
+
+    reference = doctree.children[0]
+    assert reference["refuri"] == "api.html#x"
+
+
+def test_resolve_page_anchors_warns_on_unknown_document(monkeypatch):
+    pending = page_anchor_pending("", docname="missing", anchor="x", title="Broken")
+    doctree = make_doctree(pending)
+    app = make_app(found_docs={"index"}, relative_uri="missing.html")
+
+    logger = Mock()
+    monkeypatch.setattr(
+        "sphinx_scylladb_theme.extensions.page_anchor.LOGGER", logger
+    )
+    resolve_page_anchors(app, doctree, "index")
+
+    assert logger.warning.called
+    # The link is still emitted so the build output stays navigable.
+    reference = doctree.children[0]
+    assert reference["refuri"] == "missing.html#x"


### PR DESCRIPTION
Closes https://github.com/scylladb/sphinx-scylladb-theme/issues/1270

## Problem

Currently, it is not possible to link directly to a specific endpoint on pages such as:

* https://docs.scylladb.com/manual/stable/reference/api/authorization-cache.html
* https://cloud.docs.scylladb.com/stable/api.html#tag/Account-Cluster-Network/operation/getVPCPeeringList

## Solution

Add an extension that allows links to anchors on pages generated with JavaScript.

Usage:

```text
:page-anchor:`System requirements </examples/headings#system-requirements>`
```

Unlike Sphinx `ref`, these anchors are not validated.

The extension is also compatible with Sphinx Multiversion.

## How to test

Build the documentation, open `/examples/links`, and verify that the `page-anchor` role works as expected.
